### PR TITLE
May forecasts for Sentinel team

### DIFF
--- a/data-forecasts/sentinel-gamlss/2023-04-30-sentinel-gamlss.csv
+++ b/data-forecasts/sentinel-gamlss/2023-04-30-sentinel-gamlss.csv
@@ -1,0 +1,9017 @@
+location,forecast_date,target_end_date,target,type,quantile,value
+Alabama,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+Alabama,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+Alabama,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+Alabama,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+Alabama,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+Alabama,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+Alabama,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+Alabama,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+Alabama,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+Alabama,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+Alabama,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+Alabama,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+Alabama,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+Alabama,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+Alabama,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+Alabama,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+Alabama,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+Alabama,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+Alabama,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+Alabama,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,0
+Alabama,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,0
+Alabama,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,1
+Alabama,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,4
+Alabama,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Alabama,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Alabama,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Alabama,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Alabama,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Alabama,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Alabama,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Alabama,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Alabama,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Alabama,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Alabama,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Alabama,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Alabama,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Alabama,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Alabama,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Alabama,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Alabama,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Alabama,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Alabama,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Alabama,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Alabama,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,3
+Alabama,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,7
+Alabama,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,17
+Alabama,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Alabama,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Alabama,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Alabama,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Alabama,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Alabama,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Alabama,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Alabama,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Alabama,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Alabama,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Alabama,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Alabama,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Alabama,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Alabama,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+Alabama,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+Alabama,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,2
+Alabama,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,3
+Alabama,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,4
+Alabama,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,6
+Alabama,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,10
+Alabama,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,20
+Alabama,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,41
+Alabama,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,102
+Alabama,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Alabama,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Alabama,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Alabama,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Alabama,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Alabama,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+Alabama,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,1
+Alabama,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,1
+Alabama,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,2
+Alabama,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,2
+Alabama,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,3
+Alabama,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,4
+Alabama,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,5
+Alabama,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,6
+Alabama,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,7
+Alabama,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,9
+Alabama,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,12
+Alabama,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,16
+Alabama,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,22
+Alabama,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,34
+Alabama,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,71
+Alabama,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,142
+Alabama,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,346
+Alabama,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Alabama,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Alabama,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Alabama,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Alabama,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Alabama,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Alabama,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,1
+Alabama,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+Alabama,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,2
+Alabama,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,2
+Alabama,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,2
+Alabama,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,3
+Alabama,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,4
+Alabama,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,5
+Alabama,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,6
+Alabama,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,8
+Alabama,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,10
+Alabama,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,13
+Alabama,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,18
+Alabama,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,29
+Alabama,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,59
+Alabama,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,119
+Alabama,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,291
+Alabama,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Alabama,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Alabama,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Alabama,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Alabama,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Alabama,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Alabama,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Alabama,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Alabama,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Alabama,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Alabama,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Alabama,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Alabama,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Alabama,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Alabama,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Alabama,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Alabama,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,2
+Alabama,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,2
+Alabama,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,4
+Alabama,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,6
+Alabama,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,13
+Alabama,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,27
+Alabama,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,66
+Alabama,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Alabama,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Alabama,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Alabama,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Alabama,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Alabama,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Alabama,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Alabama,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Alabama,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Alabama,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Alabama,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Alabama,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Alabama,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Alabama,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Alabama,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Alabama,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Alabama,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Alabama,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Alabama,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Alabama,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Alabama,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,2
+Alabama,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,4
+Alabama,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,11
+Alabama,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Alabama,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Alabama,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Alabama,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Alabama,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Alabama,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Alabama,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Alabama,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Alabama,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Alabama,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Alabama,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Alabama,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Alabama,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Alabama,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Alabama,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Alabama,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Alabama,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Alabama,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Alabama,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Alabama,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Alabama,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Alabama,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Alabama,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,2
+Arizona,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+Arizona,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+Arizona,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+Arizona,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+Arizona,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+Arizona,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+Arizona,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+Arizona,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+Arizona,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+Arizona,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+Arizona,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+Arizona,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+Arizona,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+Arizona,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+Arizona,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+Arizona,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+Arizona,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,1
+Arizona,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,1
+Arizona,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,2
+Arizona,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,3
+Arizona,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,7
+Arizona,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,14
+Arizona,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,34
+Arizona,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Arizona,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Arizona,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Arizona,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Arizona,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Arizona,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Arizona,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Arizona,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Arizona,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Arizona,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,1
+Arizona,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,1
+Arizona,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,1
+Arizona,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,1
+Arizona,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,2
+Arizona,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,2
+Arizona,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,3
+Arizona,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,4
+Arizona,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,6
+Arizona,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,8
+Arizona,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,13
+Arizona,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,27
+Arizona,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,55
+Arizona,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,137
+Arizona,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Arizona,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Arizona,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Arizona,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,1
+Arizona,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,2
+Arizona,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,2
+Arizona,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,3
+Arizona,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,4
+Arizona,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,5
+Arizona,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,6
+Arizona,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,8
+Arizona,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,10
+Arizona,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,12
+Arizona,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,14
+Arizona,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,18
+Arizona,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,22
+Arizona,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,28
+Arizona,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,37
+Arizona,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,52
+Arizona,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,81
+Arizona,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,166
+Arizona,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,333
+Arizona,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,817
+Arizona,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Arizona,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,1
+Arizona,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,2
+Arizona,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,5
+Arizona,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,7
+Arizona,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,10
+Arizona,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,13
+Arizona,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,16
+Arizona,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,20
+Arizona,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,24
+Arizona,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,29
+Arizona,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,35
+Arizona,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,42
+Arizona,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,51
+Arizona,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,62
+Arizona,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,77
+Arizona,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,98
+Arizona,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,129
+Arizona,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,179
+Arizona,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,280
+Arizona,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,573
+Arizona,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,1145
+Arizona,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,2806
+Arizona,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Arizona,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,1
+Arizona,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,2
+Arizona,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,4
+Arizona,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,6
+Arizona,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,8
+Arizona,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,11
+Arizona,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,13
+Arizona,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,16
+Arizona,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,20
+Arizona,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,24
+Arizona,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,29
+Arizona,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,35
+Arizona,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,43
+Arizona,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,52
+Arizona,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,65
+Arizona,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,82
+Arizona,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,108
+Arizona,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,151
+Arizona,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,235
+Arizona,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,482
+Arizona,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,962
+Arizona,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,2354
+Arizona,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Arizona,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Arizona,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Arizona,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Arizona,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,1
+Arizona,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,1
+Arizona,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,2
+Arizona,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,2
+Arizona,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,3
+Arizona,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,4
+Arizona,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,5
+Arizona,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,6
+Arizona,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,7
+Arizona,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,9
+Arizona,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,11
+Arizona,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,14
+Arizona,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,18
+Arizona,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,24
+Arizona,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,33
+Arizona,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,52
+Arizona,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,108
+Arizona,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,215
+Arizona,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,528
+Arizona,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Arizona,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Arizona,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Arizona,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Arizona,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Arizona,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Arizona,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Arizona,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Arizona,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Arizona,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Arizona,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Arizona,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Arizona,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,1
+Arizona,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,1
+Arizona,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,1
+Arizona,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,2
+Arizona,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,2
+Arizona,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,3
+Arizona,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,5
+Arizona,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,8
+Arizona,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,17
+Arizona,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,34
+Arizona,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,85
+Arizona,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Arizona,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Arizona,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Arizona,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Arizona,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Arizona,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Arizona,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Arizona,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Arizona,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Arizona,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Arizona,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Arizona,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Arizona,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Arizona,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Arizona,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Arizona,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Arizona,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Arizona,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Arizona,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,1
+Arizona,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,2
+Arizona,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,4
+Arizona,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,9
+Arizona,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,22
+Arkansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+Arkansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+Arkansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+Arkansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+Arkansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+Arkansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+Arkansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+Arkansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+Arkansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+Arkansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+Arkansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+Arkansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+Arkansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+Arkansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+Arkansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+Arkansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+Arkansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+Arkansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+Arkansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+Arkansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,0
+Arkansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,0
+Arkansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,2
+Arkansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,5
+Arkansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Arkansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Arkansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Arkansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Arkansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Arkansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Arkansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Arkansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Arkansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Arkansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Arkansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Arkansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Arkansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Arkansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Arkansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Arkansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Arkansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Arkansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Arkansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Arkansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Arkansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,3
+Arkansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,8
+Arkansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,19
+Arkansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Arkansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Arkansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Arkansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Arkansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Arkansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Arkansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Arkansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Arkansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Arkansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Arkansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Arkansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Arkansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Arkansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,2
+Arkansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+Arkansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,3
+Arkansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,3
+Arkansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,5
+Arkansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,7
+Arkansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,11
+Arkansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,23
+Arkansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,47
+Arkansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,115
+Arkansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Arkansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Arkansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Arkansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Arkansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Arkansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+Arkansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,1
+Arkansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,2
+Arkansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,2
+Arkansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,3
+Arkansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,4
+Arkansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,4
+Arkansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,5
+Arkansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,7
+Arkansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,8
+Arkansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,10
+Arkansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,13
+Arkansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,18
+Arkansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,25
+Arkansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,39
+Arkansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,80
+Arkansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,160
+Arkansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,391
+Arkansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Arkansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Arkansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Arkansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Arkansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Arkansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,1
+Arkansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,1
+Arkansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+Arkansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,2
+Arkansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,2
+Arkansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,3
+Arkansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,4
+Arkansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,4
+Arkansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,6
+Arkansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,7
+Arkansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,9
+Arkansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,11
+Arkansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,15
+Arkansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,21
+Arkansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,33
+Arkansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,67
+Arkansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,135
+Arkansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,328
+Arkansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Arkansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Arkansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Arkansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Arkansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Arkansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Arkansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Arkansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Arkansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Arkansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Arkansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Arkansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Arkansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+Arkansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Arkansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Arkansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Arkansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,2
+Arkansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,3
+Arkansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,4
+Arkansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,7
+Arkansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,15
+Arkansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,30
+Arkansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,74
+Arkansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Arkansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Arkansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Arkansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Arkansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Arkansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Arkansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Arkansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Arkansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Arkansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Arkansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Arkansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Arkansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Arkansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Arkansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Arkansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Arkansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Arkansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Arkansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Arkansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Arkansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,2
+Arkansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,5
+Arkansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,12
+Arkansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Arkansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Arkansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Arkansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Arkansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Arkansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Arkansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Arkansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Arkansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Arkansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Arkansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Arkansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Arkansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Arkansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Arkansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Arkansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Arkansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Arkansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Arkansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Arkansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Arkansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Arkansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Arkansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,3
+California,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+California,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+California,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+California,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+California,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+California,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+California,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+California,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+California,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+California,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+California,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+California,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+California,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+California,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,1
+California,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,1
+California,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,1
+California,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,2
+California,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,3
+California,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,4
+California,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,6
+California,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,14
+California,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,28
+California,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,69
+California,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+California,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+California,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+California,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+California,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+California,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+California,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,1
+California,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,1
+California,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,1
+California,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,2
+California,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,2
+California,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,3
+California,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,4
+California,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,4
+California,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,6
+California,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,7
+California,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,9
+California,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,12
+California,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,17
+California,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,27
+California,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,56
+California,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,112
+California,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,274
+California,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+California,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+California,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,1
+California,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,2
+California,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,4
+California,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,6
+California,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,7
+California,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,9
+California,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,11
+California,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,14
+California,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,17
+California,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,20
+California,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,25
+California,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,30
+California,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,37
+California,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,45
+California,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,58
+California,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,76
+California,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,106
+California,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,165
+California,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,337
+California,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,672
+California,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,1641
+California,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,1
+California,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,3
+California,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,5
+California,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,10
+California,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,15
+California,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,21
+California,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,27
+California,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,33
+California,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,41
+California,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,50
+California,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,60
+California,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,72
+California,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,86
+California,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,105
+California,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,128
+California,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,158
+California,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,200
+California,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,263
+California,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,366
+California,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,569
+California,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,1162
+California,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,2312
+California,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,5634
+California,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,1
+California,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,2
+California,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,4
+California,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,8
+California,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,13
+California,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,17
+California,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,22
+California,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,28
+California,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,34
+California,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,42
+California,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,50
+California,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,60
+California,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,73
+California,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,88
+California,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,107
+California,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,133
+California,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,169
+California,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,222
+California,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,308
+California,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,479
+California,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,977
+California,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,1941
+California,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,4721
+California,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+California,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+California,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+California,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,1
+California,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,2
+California,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,3
+California,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,5
+California,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,6
+California,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,7
+California,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,9
+California,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,11
+California,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,13
+California,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,16
+California,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,19
+California,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,24
+California,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,29
+California,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,37
+California,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,49
+California,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,69
+California,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,107
+California,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,218
+California,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,435
+California,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,1058
+California,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+California,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+California,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+California,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+California,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+California,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+California,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+California,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+California,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,1
+California,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,1
+California,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,1
+California,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,2
+California,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,2
+California,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,3
+California,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,3
+California,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,4
+California,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,5
+California,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,7
+California,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,10
+California,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,17
+California,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,35
+California,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,70
+California,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,171
+California,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+California,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+California,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+California,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+California,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+California,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+California,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+California,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+California,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+California,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+California,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+California,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+California,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+California,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+California,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+California,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,1
+California,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,1
+California,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,1
+California,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,2
+California,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,4
+California,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,9
+California,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,18
+California,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,44
+Colorado,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+Colorado,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+Colorado,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+Colorado,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+Colorado,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+Colorado,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+Colorado,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+Colorado,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+Colorado,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+Colorado,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+Colorado,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+Colorado,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+Colorado,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+Colorado,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+Colorado,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+Colorado,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+Colorado,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+Colorado,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+Colorado,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+Colorado,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,1
+Colorado,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,2
+Colorado,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,4
+Colorado,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,11
+Colorado,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Colorado,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Colorado,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Colorado,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Colorado,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Colorado,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Colorado,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Colorado,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Colorado,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Colorado,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Colorado,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Colorado,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Colorado,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Colorado,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Colorado,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Colorado,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,1
+Colorado,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,1
+Colorado,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,1
+Colorado,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,2
+Colorado,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,4
+Colorado,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,9
+Colorado,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,18
+Colorado,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,46
+Colorado,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Colorado,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Colorado,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Colorado,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Colorado,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Colorado,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Colorado,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,1
+Colorado,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,1
+Colorado,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,1
+Colorado,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,2
+Colorado,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,2
+Colorado,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,3
+Colorado,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,3
+Colorado,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,4
+Colorado,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,5
+Colorado,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,7
+Colorado,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,9
+Colorado,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,12
+Colorado,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,17
+Colorado,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,27
+Colorado,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,55
+Colorado,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,112
+Colorado,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,275
+Colorado,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Colorado,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Colorado,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Colorado,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,1
+Colorado,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,2
+Colorado,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,3
+Colorado,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,4
+Colorado,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,5
+Colorado,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,6
+Colorado,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,8
+Colorado,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,9
+Colorado,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,11
+Colorado,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,14
+Colorado,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,17
+Colorado,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,20
+Colorado,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,25
+Colorado,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,32
+Colorado,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,43
+Colorado,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,60
+Colorado,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,93
+Colorado,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,192
+Colorado,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,384
+Colorado,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,945
+Colorado,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Colorado,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Colorado,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Colorado,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,1
+Colorado,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,2
+Colorado,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,2
+Colorado,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,3
+Colorado,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,4
+Colorado,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,5
+Colorado,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,6
+Colorado,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,8
+Colorado,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,9
+Colorado,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,11
+Colorado,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,14
+Colorado,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,17
+Colorado,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,21
+Colorado,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,27
+Colorado,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,36
+Colorado,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,50
+Colorado,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,78
+Colorado,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,161
+Colorado,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,323
+Colorado,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,793
+Colorado,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Colorado,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Colorado,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Colorado,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Colorado,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Colorado,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Colorado,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Colorado,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Colorado,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,1
+Colorado,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,1
+Colorado,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,1
+Colorado,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,2
+Colorado,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,2
+Colorado,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,3
+Colorado,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,3
+Colorado,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,4
+Colorado,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,6
+Colorado,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,8
+Colorado,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,11
+Colorado,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,17
+Colorado,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,36
+Colorado,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,72
+Colorado,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,178
+Colorado,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Colorado,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Colorado,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Colorado,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Colorado,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Colorado,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Colorado,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Colorado,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Colorado,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Colorado,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Colorado,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Colorado,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Colorado,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Colorado,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Colorado,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Colorado,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Colorado,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Colorado,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,1
+Colorado,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,1
+Colorado,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,2
+Colorado,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,5
+Colorado,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,11
+Colorado,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,29
+Colorado,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Colorado,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Colorado,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Colorado,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Colorado,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Colorado,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Colorado,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Colorado,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Colorado,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Colorado,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Colorado,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Colorado,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Colorado,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Colorado,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Colorado,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Colorado,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Colorado,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Colorado,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Colorado,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Colorado,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Colorado,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,1
+Colorado,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,3
+Colorado,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,7
+Connecticut,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+Connecticut,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+Connecticut,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+Connecticut,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+Connecticut,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+Connecticut,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+Connecticut,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+Connecticut,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+Connecticut,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+Connecticut,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+Connecticut,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+Connecticut,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+Connecticut,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+Connecticut,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+Connecticut,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+Connecticut,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+Connecticut,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+Connecticut,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+Connecticut,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+Connecticut,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,0
+Connecticut,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,0
+Connecticut,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,0
+Connecticut,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,1
+Connecticut,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Connecticut,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Connecticut,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Connecticut,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Connecticut,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Connecticut,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Connecticut,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Connecticut,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Connecticut,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Connecticut,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Connecticut,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Connecticut,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Connecticut,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Connecticut,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Connecticut,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Connecticut,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Connecticut,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Connecticut,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Connecticut,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Connecticut,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Connecticut,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Connecticut,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,3
+Connecticut,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,7
+Connecticut,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Connecticut,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Connecticut,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Connecticut,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Connecticut,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Connecticut,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Connecticut,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Connecticut,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Connecticut,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Connecticut,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Connecticut,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Connecticut,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Connecticut,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Connecticut,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+Connecticut,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+Connecticut,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+Connecticut,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+Connecticut,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,1
+Connecticut,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,2
+Connecticut,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,4
+Connecticut,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,8
+Connecticut,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,17
+Connecticut,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,43
+Connecticut,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Connecticut,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Connecticut,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Connecticut,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Connecticut,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Connecticut,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Connecticut,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Connecticut,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+Connecticut,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+Connecticut,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,1
+Connecticut,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,1
+Connecticut,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,1
+Connecticut,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,2
+Connecticut,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,2
+Connecticut,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,3
+Connecticut,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,3
+Connecticut,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,5
+Connecticut,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,6
+Connecticut,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,9
+Connecticut,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,14
+Connecticut,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,30
+Connecticut,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,60
+Connecticut,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,147
+Connecticut,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Connecticut,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Connecticut,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Connecticut,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Connecticut,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Connecticut,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Connecticut,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Connecticut,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Connecticut,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+Connecticut,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+Connecticut,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,1
+Connecticut,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,1
+Connecticut,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,1
+Connecticut,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,2
+Connecticut,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,2
+Connecticut,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,3
+Connecticut,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,4
+Connecticut,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,5
+Connecticut,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,7
+Connecticut,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,12
+Connecticut,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,25
+Connecticut,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,50
+Connecticut,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,124
+Connecticut,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Connecticut,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Connecticut,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Connecticut,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Connecticut,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Connecticut,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Connecticut,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Connecticut,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Connecticut,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Connecticut,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Connecticut,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Connecticut,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Connecticut,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Connecticut,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Connecticut,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Connecticut,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Connecticut,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Connecticut,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Connecticut,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+Connecticut,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,2
+Connecticut,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,5
+Connecticut,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,11
+Connecticut,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,28
+Connecticut,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Connecticut,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Connecticut,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Connecticut,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Connecticut,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Connecticut,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Connecticut,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Connecticut,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Connecticut,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Connecticut,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Connecticut,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Connecticut,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Connecticut,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Connecticut,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Connecticut,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Connecticut,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Connecticut,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Connecticut,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Connecticut,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Connecticut,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Connecticut,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Connecticut,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,1
+Connecticut,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,4
+Connecticut,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Connecticut,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Connecticut,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Connecticut,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Connecticut,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Connecticut,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Connecticut,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Connecticut,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Connecticut,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Connecticut,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Connecticut,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Connecticut,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Connecticut,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Connecticut,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Connecticut,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Connecticut,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Connecticut,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Connecticut,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Connecticut,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Connecticut,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Connecticut,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Connecticut,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Connecticut,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,1
+Delaware,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+Delaware,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+Delaware,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+Delaware,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+Delaware,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+Delaware,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+Delaware,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+Delaware,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+Delaware,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+Delaware,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+Delaware,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+Delaware,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+Delaware,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+Delaware,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+Delaware,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+Delaware,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+Delaware,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+Delaware,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+Delaware,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+Delaware,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,0
+Delaware,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,0
+Delaware,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,0
+Delaware,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,0
+Delaware,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Delaware,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Delaware,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Delaware,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Delaware,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Delaware,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Delaware,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Delaware,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Delaware,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Delaware,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Delaware,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Delaware,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Delaware,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Delaware,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Delaware,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Delaware,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Delaware,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Delaware,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Delaware,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Delaware,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Delaware,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Delaware,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+Delaware,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,1
+Delaware,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Delaware,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Delaware,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Delaware,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Delaware,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Delaware,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Delaware,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Delaware,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Delaware,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Delaware,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Delaware,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Delaware,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Delaware,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Delaware,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+Delaware,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+Delaware,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,0
+Delaware,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,0
+Delaware,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,0
+Delaware,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,0
+Delaware,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,0
+Delaware,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,2
+Delaware,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,4
+Delaware,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,10
+Delaware,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Delaware,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Delaware,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Delaware,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Delaware,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Delaware,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Delaware,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Delaware,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+Delaware,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+Delaware,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,0
+Delaware,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,0
+Delaware,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,0
+Delaware,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,0
+Delaware,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,0
+Delaware,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,0
+Delaware,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,0
+Delaware,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,1
+Delaware,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,1
+Delaware,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,2
+Delaware,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,3
+Delaware,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,7
+Delaware,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,14
+Delaware,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,34
+Delaware,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Delaware,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Delaware,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Delaware,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Delaware,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Delaware,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Delaware,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Delaware,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Delaware,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+Delaware,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+Delaware,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,0
+Delaware,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,0
+Delaware,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,0
+Delaware,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,0
+Delaware,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,0
+Delaware,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,0
+Delaware,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,0
+Delaware,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,1
+Delaware,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,1
+Delaware,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,2
+Delaware,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,5
+Delaware,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,11
+Delaware,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,29
+Delaware,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Delaware,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Delaware,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Delaware,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Delaware,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Delaware,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Delaware,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Delaware,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Delaware,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Delaware,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Delaware,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Delaware,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Delaware,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Delaware,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Delaware,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Delaware,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Delaware,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Delaware,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+Delaware,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,0
+Delaware,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,0
+Delaware,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,1
+Delaware,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,2
+Delaware,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,6
+Delaware,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Delaware,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Delaware,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Delaware,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Delaware,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Delaware,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Delaware,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Delaware,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Delaware,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Delaware,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Delaware,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Delaware,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Delaware,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Delaware,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Delaware,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Delaware,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Delaware,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Delaware,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Delaware,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Delaware,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Delaware,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Delaware,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Delaware,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,1
+Delaware,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Delaware,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Delaware,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Delaware,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Delaware,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Delaware,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Delaware,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Delaware,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Delaware,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Delaware,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Delaware,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Delaware,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Delaware,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Delaware,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Delaware,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Delaware,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Delaware,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Delaware,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Delaware,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Delaware,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Delaware,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Delaware,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Delaware,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+District of Columbia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+District of Columbia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+District of Columbia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+District of Columbia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+District of Columbia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+District of Columbia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+District of Columbia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+District of Columbia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+District of Columbia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+District of Columbia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+District of Columbia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+District of Columbia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+District of Columbia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+District of Columbia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+District of Columbia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+District of Columbia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+District of Columbia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+District of Columbia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+District of Columbia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+District of Columbia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,0
+District of Columbia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,0
+District of Columbia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,0
+District of Columbia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,1
+District of Columbia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+District of Columbia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+District of Columbia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+District of Columbia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+District of Columbia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+District of Columbia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+District of Columbia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+District of Columbia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+District of Columbia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+District of Columbia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+District of Columbia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+District of Columbia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+District of Columbia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+District of Columbia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+District of Columbia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+District of Columbia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+District of Columbia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+District of Columbia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+District of Columbia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+District of Columbia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+District of Columbia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+District of Columbia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,1
+District of Columbia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,4
+District of Columbia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+District of Columbia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+District of Columbia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+District of Columbia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+District of Columbia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+District of Columbia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+District of Columbia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+District of Columbia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+District of Columbia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+District of Columbia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+District of Columbia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+District of Columbia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+District of Columbia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+District of Columbia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+District of Columbia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+District of Columbia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,0
+District of Columbia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,0
+District of Columbia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,1
+District of Columbia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,1
+District of Columbia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,2
+District of Columbia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,4
+District of Columbia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,9
+District of Columbia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,24
+District of Columbia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+District of Columbia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+District of Columbia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+District of Columbia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+District of Columbia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+District of Columbia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+District of Columbia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+District of Columbia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+District of Columbia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+District of Columbia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,0
+District of Columbia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,0
+District of Columbia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,0
+District of Columbia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,1
+District of Columbia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,1
+District of Columbia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,1
+District of Columbia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,2
+District of Columbia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,2
+District of Columbia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,3
+District of Columbia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,5
+District of Columbia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,8
+District of Columbia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,16
+District of Columbia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,33
+District of Columbia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,82
+District of Columbia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+District of Columbia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+District of Columbia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+District of Columbia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+District of Columbia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+District of Columbia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+District of Columbia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+District of Columbia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+District of Columbia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+District of Columbia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+District of Columbia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,0
+District of Columbia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,0
+District of Columbia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,0
+District of Columbia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,1
+District of Columbia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,1
+District of Columbia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,1
+District of Columbia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,2
+District of Columbia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,3
+District of Columbia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,4
+District of Columbia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,6
+District of Columbia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,14
+District of Columbia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,28
+District of Columbia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,69
+District of Columbia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+District of Columbia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+District of Columbia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+District of Columbia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+District of Columbia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+District of Columbia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+District of Columbia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+District of Columbia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+District of Columbia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+District of Columbia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+District of Columbia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+District of Columbia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+District of Columbia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+District of Columbia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+District of Columbia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+District of Columbia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+District of Columbia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+District of Columbia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+District of Columbia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,0
+District of Columbia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,1
+District of Columbia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,3
+District of Columbia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,6
+District of Columbia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,15
+District of Columbia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+District of Columbia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+District of Columbia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+District of Columbia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+District of Columbia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+District of Columbia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+District of Columbia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+District of Columbia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+District of Columbia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+District of Columbia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+District of Columbia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+District of Columbia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+District of Columbia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+District of Columbia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+District of Columbia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+District of Columbia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+District of Columbia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+District of Columbia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+District of Columbia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+District of Columbia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+District of Columbia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+District of Columbia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+District of Columbia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,2
+District of Columbia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+District of Columbia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+District of Columbia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+District of Columbia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+District of Columbia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+District of Columbia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+District of Columbia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+District of Columbia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+District of Columbia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+District of Columbia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+District of Columbia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+District of Columbia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+District of Columbia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+District of Columbia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+District of Columbia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+District of Columbia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+District of Columbia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+District of Columbia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+District of Columbia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+District of Columbia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+District of Columbia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+District of Columbia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+District of Columbia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Florida,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+Florida,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+Florida,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+Florida,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+Florida,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+Florida,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+Florida,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+Florida,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+Florida,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+Florida,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+Florida,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+Florida,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+Florida,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+Florida,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+Florida,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+Florida,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+Florida,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+Florida,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+Florida,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+Florida,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,0
+Florida,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,1
+Florida,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,2
+Florida,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,6
+Florida,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Florida,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Florida,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Florida,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Florida,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Florida,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Florida,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Florida,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Florida,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Florida,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Florida,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Florida,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Florida,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Florida,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Florida,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Florida,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Florida,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Florida,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,1
+Florida,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Florida,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,2
+Florida,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,5
+Florida,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,10
+Florida,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,26
+Florida,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Florida,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Florida,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Florida,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Florida,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Florida,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Florida,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Florida,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Florida,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Florida,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+Florida,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Florida,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Florida,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,2
+Florida,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,2
+Florida,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,3
+Florida,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,4
+Florida,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,5
+Florida,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,6
+Florida,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,9
+Florida,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,15
+Florida,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,31
+Florida,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,62
+Florida,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,153
+Florida,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Florida,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Florida,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Florida,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Florida,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,1
+Florida,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+Florida,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,2
+Florida,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,2
+Florida,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,3
+Florida,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,4
+Florida,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,5
+Florida,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,6
+Florida,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,7
+Florida,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,9
+Florida,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,11
+Florida,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,14
+Florida,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,18
+Florida,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,24
+Florida,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,33
+Florida,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,52
+Florida,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,107
+Florida,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,214
+Florida,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,522
+Florida,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Florida,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Florida,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Florida,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Florida,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,1
+Florida,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,1
+Florida,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,1
+Florida,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,2
+Florida,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,3
+Florida,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,3
+Florida,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,4
+Florida,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,5
+Florida,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,6
+Florida,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,8
+Florida,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,9
+Florida,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,12
+Florida,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,15
+Florida,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,20
+Florida,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,28
+Florida,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,44
+Florida,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,90
+Florida,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,179
+Florida,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,438
+Florida,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Florida,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Florida,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Florida,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Florida,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Florida,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Florida,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Florida,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Florida,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Florida,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Florida,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Florida,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,1
+Florida,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+Florida,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Florida,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,2
+Florida,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,2
+Florida,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,3
+Florida,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,4
+Florida,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,6
+Florida,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,9
+Florida,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,20
+Florida,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,40
+Florida,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,99
+Florida,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Florida,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Florida,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Florida,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Florida,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Florida,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Florida,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Florida,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Florida,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Florida,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Florida,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Florida,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Florida,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Florida,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Florida,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Florida,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Florida,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Florida,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Florida,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Florida,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Florida,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,3
+Florida,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,6
+Florida,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,16
+Florida,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Florida,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Florida,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Florida,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Florida,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Florida,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Florida,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Florida,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Florida,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Florida,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Florida,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Florida,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Florida,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Florida,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Florida,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Florida,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Florida,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Florida,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Florida,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Florida,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Florida,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Florida,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Florida,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,4
+Georgia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+Georgia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+Georgia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+Georgia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+Georgia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+Georgia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+Georgia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+Georgia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+Georgia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+Georgia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+Georgia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+Georgia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+Georgia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+Georgia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+Georgia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+Georgia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+Georgia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+Georgia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+Georgia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+Georgia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,0
+Georgia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,1
+Georgia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,2
+Georgia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,6
+Georgia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Georgia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Georgia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Georgia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Georgia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Georgia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Georgia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Georgia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Georgia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Georgia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Georgia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Georgia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Georgia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Georgia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Georgia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Georgia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Georgia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Georgia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Georgia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Georgia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,2
+Georgia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,4
+Georgia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,9
+Georgia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,23
+Georgia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Georgia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Georgia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Georgia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Georgia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Georgia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Georgia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Georgia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Georgia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Georgia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+Georgia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Georgia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Georgia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Georgia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,2
+Georgia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+Georgia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,3
+Georgia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,4
+Georgia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,6
+Georgia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,8
+Georgia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,13
+Georgia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,27
+Georgia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,55
+Georgia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,135
+Georgia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Georgia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Georgia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Georgia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Georgia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,1
+Georgia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+Georgia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,2
+Georgia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,2
+Georgia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,3
+Georgia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,3
+Georgia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,4
+Georgia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,5
+Georgia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,7
+Georgia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,8
+Georgia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,10
+Georgia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,12
+Georgia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,16
+Georgia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,21
+Georgia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,29
+Georgia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,46
+Georgia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,95
+Georgia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,189
+Georgia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,462
+Georgia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Georgia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Georgia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Georgia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Georgia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Georgia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,1
+Georgia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,1
+Georgia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,2
+Georgia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,2
+Georgia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,3
+Georgia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,4
+Georgia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,4
+Georgia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,5
+Georgia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,7
+Georgia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,8
+Georgia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,10
+Georgia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,13
+Georgia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,18
+Georgia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,25
+Georgia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,39
+Georgia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,80
+Georgia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,159
+Georgia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,388
+Georgia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Georgia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Georgia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Georgia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Georgia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Georgia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Georgia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Georgia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Georgia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Georgia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Georgia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Georgia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,1
+Georgia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+Georgia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Georgia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Georgia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,2
+Georgia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,3
+Georgia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,4
+Georgia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,5
+Georgia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,8
+Georgia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,18
+Georgia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,36
+Georgia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,88
+Georgia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Georgia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Georgia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Georgia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Georgia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Georgia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Georgia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Georgia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Georgia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Georgia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Georgia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Georgia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Georgia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Georgia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Georgia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Georgia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Georgia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Georgia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Georgia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Georgia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Georgia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,2
+Georgia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,5
+Georgia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,14
+Georgia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Georgia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Georgia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Georgia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Georgia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Georgia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Georgia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Georgia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Georgia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Georgia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Georgia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Georgia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Georgia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Georgia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Georgia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Georgia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Georgia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Georgia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Georgia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Georgia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Georgia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Georgia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Georgia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,3
+Idaho,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+Idaho,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+Idaho,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+Idaho,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+Idaho,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+Idaho,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+Idaho,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+Idaho,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+Idaho,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+Idaho,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+Idaho,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+Idaho,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+Idaho,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+Idaho,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+Idaho,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+Idaho,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+Idaho,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+Idaho,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+Idaho,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+Idaho,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,0
+Idaho,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,0
+Idaho,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,1
+Idaho,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,2
+Idaho,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Idaho,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Idaho,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Idaho,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Idaho,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Idaho,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Idaho,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Idaho,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Idaho,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Idaho,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Idaho,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Idaho,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Idaho,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Idaho,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Idaho,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Idaho,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Idaho,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Idaho,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Idaho,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Idaho,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Idaho,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,2
+Idaho,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,4
+Idaho,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,11
+Idaho,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Idaho,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Idaho,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Idaho,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Idaho,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Idaho,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Idaho,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Idaho,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Idaho,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Idaho,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Idaho,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Idaho,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Idaho,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Idaho,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+Idaho,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+Idaho,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+Idaho,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,2
+Idaho,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,2
+Idaho,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,4
+Idaho,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,6
+Idaho,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,13
+Idaho,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,27
+Idaho,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,67
+Idaho,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Idaho,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Idaho,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Idaho,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Idaho,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Idaho,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Idaho,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Idaho,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,1
+Idaho,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,1
+Idaho,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,1
+Idaho,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,2
+Idaho,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,2
+Idaho,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,3
+Idaho,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,4
+Idaho,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,5
+Idaho,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,6
+Idaho,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,7
+Idaho,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,10
+Idaho,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,14
+Idaho,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,22
+Idaho,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,46
+Idaho,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,93
+Idaho,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,228
+Idaho,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Idaho,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Idaho,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Idaho,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Idaho,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Idaho,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Idaho,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Idaho,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+Idaho,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,1
+Idaho,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,1
+Idaho,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,1
+Idaho,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,2
+Idaho,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,2
+Idaho,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,3
+Idaho,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,4
+Idaho,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,5
+Idaho,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,6
+Idaho,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,8
+Idaho,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,12
+Idaho,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,19
+Idaho,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,39
+Idaho,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,78
+Idaho,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,192
+Idaho,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Idaho,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Idaho,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Idaho,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Idaho,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Idaho,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Idaho,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Idaho,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Idaho,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Idaho,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Idaho,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Idaho,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Idaho,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Idaho,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Idaho,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Idaho,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Idaho,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Idaho,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Idaho,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,2
+Idaho,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,4
+Idaho,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,8
+Idaho,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,17
+Idaho,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,44
+Idaho,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Idaho,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Idaho,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Idaho,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Idaho,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Idaho,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Idaho,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Idaho,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Idaho,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Idaho,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Idaho,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Idaho,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Idaho,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Idaho,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Idaho,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Idaho,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Idaho,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Idaho,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Idaho,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Idaho,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Idaho,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,1
+Idaho,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,2
+Idaho,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,7
+Idaho,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Idaho,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Idaho,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Idaho,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Idaho,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Idaho,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Idaho,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Idaho,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Idaho,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Idaho,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Idaho,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Idaho,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Idaho,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Idaho,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Idaho,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Idaho,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Idaho,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Idaho,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Idaho,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Idaho,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Idaho,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Idaho,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Idaho,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,1
+Illinois,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+Illinois,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+Illinois,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+Illinois,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+Illinois,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+Illinois,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+Illinois,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+Illinois,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+Illinois,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+Illinois,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+Illinois,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+Illinois,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+Illinois,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+Illinois,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+Illinois,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+Illinois,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+Illinois,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+Illinois,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+Illinois,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+Illinois,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,1
+Illinois,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,2
+Illinois,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,5
+Illinois,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,13
+Illinois,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Illinois,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Illinois,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Illinois,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Illinois,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Illinois,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Illinois,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Illinois,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Illinois,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Illinois,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Illinois,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Illinois,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Illinois,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Illinois,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Illinois,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,1
+Illinois,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,1
+Illinois,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,1
+Illinois,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,2
+Illinois,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,3
+Illinois,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,5
+Illinois,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,10
+Illinois,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,21
+Illinois,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,53
+Illinois,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Illinois,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Illinois,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Illinois,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Illinois,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Illinois,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,1
+Illinois,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,1
+Illinois,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,1
+Illinois,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,2
+Illinois,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,2
+Illinois,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,3
+Illinois,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,3
+Illinois,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,4
+Illinois,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,5
+Illinois,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,6
+Illinois,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,8
+Illinois,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,10
+Illinois,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,14
+Illinois,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,19
+Illinois,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,31
+Illinois,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,64
+Illinois,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,128
+Illinois,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,314
+Illinois,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Illinois,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Illinois,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Illinois,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,1
+Illinois,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,2
+Illinois,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,3
+Illinois,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,4
+Illinois,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,6
+Illinois,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,7
+Illinois,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,9
+Illinois,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,11
+Illinois,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,13
+Illinois,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,16
+Illinois,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,19
+Illinois,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,23
+Illinois,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,29
+Illinois,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,37
+Illinois,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,49
+Illinois,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,69
+Illinois,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,107
+Illinois,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,220
+Illinois,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,439
+Illinois,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,1075
+Illinois,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Illinois,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Illinois,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Illinois,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,1
+Illinois,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,2
+Illinois,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,3
+Illinois,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,4
+Illinois,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,5
+Illinois,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,6
+Illinois,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,7
+Illinois,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,9
+Illinois,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,11
+Illinois,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,13
+Illinois,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,16
+Illinois,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,20
+Illinois,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,25
+Illinois,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,31
+Illinois,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,41
+Illinois,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,58
+Illinois,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,90
+Illinois,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,185
+Illinois,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,369
+Illinois,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,902
+Illinois,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Illinois,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Illinois,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Illinois,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Illinois,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Illinois,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Illinois,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Illinois,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,1
+Illinois,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,1
+Illinois,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,1
+Illinois,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,2
+Illinois,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,2
+Illinois,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,2
+Illinois,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,3
+Illinois,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,4
+Illinois,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,5
+Illinois,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,7
+Illinois,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,9
+Illinois,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,12
+Illinois,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,20
+Illinois,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,41
+Illinois,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,83
+Illinois,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,203
+Illinois,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Illinois,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Illinois,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Illinois,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Illinois,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Illinois,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Illinois,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Illinois,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Illinois,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Illinois,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Illinois,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Illinois,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Illinois,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Illinois,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Illinois,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Illinois,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Illinois,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,1
+Illinois,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,1
+Illinois,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,2
+Illinois,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,3
+Illinois,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,6
+Illinois,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,13
+Illinois,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,33
+Illinois,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Illinois,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Illinois,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Illinois,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Illinois,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Illinois,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Illinois,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Illinois,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Illinois,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Illinois,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Illinois,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Illinois,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Illinois,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Illinois,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Illinois,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Illinois,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Illinois,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Illinois,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Illinois,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Illinois,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Illinois,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,1
+Illinois,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,3
+Illinois,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,8
+Indiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+Indiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+Indiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+Indiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+Indiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+Indiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+Indiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+Indiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+Indiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+Indiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+Indiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+Indiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+Indiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+Indiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+Indiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+Indiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+Indiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+Indiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+Indiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+Indiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,0
+Indiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,0
+Indiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,1
+Indiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,4
+Indiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Indiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Indiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Indiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Indiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Indiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Indiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Indiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Indiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Indiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Indiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Indiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Indiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Indiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Indiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Indiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Indiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Indiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Indiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Indiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Indiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,3
+Indiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,7
+Indiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,19
+Indiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Indiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Indiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Indiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Indiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Indiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Indiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Indiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Indiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Indiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Indiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Indiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Indiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Indiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+Indiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+Indiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,2
+Indiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,3
+Indiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,5
+Indiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,7
+Indiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,10
+Indiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,22
+Indiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,45
+Indiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,110
+Indiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Indiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Indiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Indiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Indiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Indiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+Indiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,1
+Indiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,2
+Indiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,2
+Indiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,3
+Indiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,3
+Indiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,4
+Indiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,5
+Indiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,6
+Indiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,8
+Indiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,10
+Indiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,13
+Indiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,17
+Indiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,24
+Indiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,37
+Indiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,77
+Indiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,153
+Indiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,375
+Indiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Indiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Indiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Indiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Indiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Indiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,1
+Indiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,1
+Indiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+Indiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,2
+Indiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,2
+Indiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,3
+Indiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,3
+Indiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,4
+Indiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,5
+Indiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,7
+Indiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,8
+Indiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,11
+Indiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,14
+Indiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,20
+Indiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,31
+Indiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,65
+Indiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,129
+Indiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,314
+Indiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Indiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Indiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Indiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Indiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Indiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Indiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Indiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Indiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Indiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Indiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Indiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Indiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Indiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Indiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Indiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Indiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,2
+Indiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,3
+Indiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,4
+Indiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,7
+Indiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,14
+Indiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,29
+Indiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,71
+Indiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Indiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Indiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Indiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Indiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Indiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Indiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Indiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Indiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Indiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Indiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Indiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Indiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Indiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Indiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Indiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Indiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Indiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Indiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Indiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Indiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,2
+Indiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,4
+Indiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,12
+Indiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Indiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Indiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Indiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Indiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Indiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Indiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Indiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Indiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Indiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Indiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Indiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Indiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Indiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Indiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Indiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Indiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Indiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Indiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Indiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Indiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Indiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Indiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,3
+Iowa,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+Iowa,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+Iowa,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+Iowa,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+Iowa,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+Iowa,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+Iowa,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+Iowa,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+Iowa,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+Iowa,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+Iowa,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+Iowa,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+Iowa,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+Iowa,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+Iowa,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+Iowa,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+Iowa,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+Iowa,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+Iowa,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+Iowa,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,0
+Iowa,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,0
+Iowa,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,1
+Iowa,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,3
+Iowa,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Iowa,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Iowa,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Iowa,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Iowa,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Iowa,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Iowa,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Iowa,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Iowa,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Iowa,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Iowa,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Iowa,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Iowa,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Iowa,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Iowa,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Iowa,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Iowa,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Iowa,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Iowa,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Iowa,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Iowa,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,2
+Iowa,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,5
+Iowa,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,14
+Iowa,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Iowa,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Iowa,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Iowa,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Iowa,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Iowa,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Iowa,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Iowa,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Iowa,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Iowa,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Iowa,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Iowa,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Iowa,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Iowa,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+Iowa,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+Iowa,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,2
+Iowa,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,2
+Iowa,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,3
+Iowa,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,5
+Iowa,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,8
+Iowa,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,16
+Iowa,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,33
+Iowa,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,82
+Iowa,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Iowa,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Iowa,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Iowa,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Iowa,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Iowa,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Iowa,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,1
+Iowa,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,1
+Iowa,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,1
+Iowa,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,2
+Iowa,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,2
+Iowa,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,3
+Iowa,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,4
+Iowa,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,4
+Iowa,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,6
+Iowa,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,7
+Iowa,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,9
+Iowa,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,12
+Iowa,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,17
+Iowa,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,27
+Iowa,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,56
+Iowa,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,113
+Iowa,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,278
+Iowa,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Iowa,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Iowa,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Iowa,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Iowa,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Iowa,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Iowa,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Iowa,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+Iowa,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,1
+Iowa,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,1
+Iowa,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,2
+Iowa,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,2
+Iowa,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,3
+Iowa,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,4
+Iowa,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,5
+Iowa,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,6
+Iowa,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,8
+Iowa,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,10
+Iowa,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,14
+Iowa,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,23
+Iowa,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,47
+Iowa,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,95
+Iowa,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,234
+Iowa,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Iowa,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Iowa,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Iowa,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Iowa,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Iowa,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Iowa,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Iowa,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Iowa,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Iowa,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Iowa,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Iowa,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Iowa,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Iowa,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Iowa,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Iowa,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Iowa,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Iowa,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,2
+Iowa,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,3
+Iowa,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,5
+Iowa,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,10
+Iowa,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,21
+Iowa,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,53
+Iowa,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Iowa,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Iowa,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Iowa,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Iowa,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Iowa,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Iowa,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Iowa,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Iowa,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Iowa,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Iowa,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Iowa,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Iowa,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Iowa,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Iowa,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Iowa,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Iowa,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Iowa,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Iowa,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Iowa,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Iowa,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,1
+Iowa,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,3
+Iowa,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,8
+Iowa,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Iowa,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Iowa,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Iowa,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Iowa,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Iowa,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Iowa,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Iowa,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Iowa,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Iowa,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Iowa,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Iowa,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Iowa,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Iowa,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Iowa,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Iowa,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Iowa,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Iowa,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Iowa,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Iowa,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Iowa,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Iowa,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Iowa,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,2
+Kansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+Kansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+Kansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+Kansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+Kansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+Kansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+Kansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+Kansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+Kansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+Kansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+Kansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+Kansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+Kansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+Kansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+Kansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+Kansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+Kansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+Kansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+Kansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+Kansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,0
+Kansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,1
+Kansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,2
+Kansas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,6
+Kansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Kansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Kansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Kansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Kansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Kansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Kansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Kansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Kansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Kansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Kansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Kansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Kansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Kansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Kansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Kansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Kansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Kansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,1
+Kansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Kansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,2
+Kansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,4
+Kansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,9
+Kansas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,24
+Kansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Kansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Kansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Kansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Kansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Kansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Kansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Kansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Kansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Kansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+Kansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Kansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Kansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,2
+Kansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,2
+Kansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,3
+Kansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,3
+Kansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,4
+Kansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,6
+Kansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,9
+Kansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,14
+Kansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,29
+Kansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,58
+Kansas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,141
+Kansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Kansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Kansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Kansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Kansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,1
+Kansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+Kansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,2
+Kansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,2
+Kansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,3
+Kansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,4
+Kansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,5
+Kansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,6
+Kansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,7
+Kansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,8
+Kansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,10
+Kansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,13
+Kansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,17
+Kansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,22
+Kansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,31
+Kansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,49
+Kansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,99
+Kansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,198
+Kansas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,482
+Kansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Kansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Kansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Kansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Kansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,1
+Kansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,1
+Kansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,1
+Kansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,2
+Kansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,2
+Kansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,3
+Kansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,4
+Kansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,5
+Kansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,6
+Kansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,7
+Kansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,9
+Kansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,11
+Kansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,14
+Kansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,19
+Kansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,26
+Kansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,41
+Kansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,84
+Kansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,166
+Kansas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,404
+Kansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Kansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Kansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Kansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Kansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Kansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Kansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Kansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Kansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Kansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Kansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Kansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,1
+Kansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+Kansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Kansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Kansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,2
+Kansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,3
+Kansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,4
+Kansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,5
+Kansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,9
+Kansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,19
+Kansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,37
+Kansas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,92
+Kansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Kansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Kansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Kansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Kansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Kansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Kansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Kansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Kansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Kansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Kansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Kansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Kansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Kansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Kansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Kansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Kansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Kansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Kansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Kansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Kansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,3
+Kansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,6
+Kansas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,15
+Kansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Kansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Kansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Kansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Kansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Kansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Kansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Kansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Kansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Kansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Kansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Kansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Kansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Kansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Kansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Kansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Kansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Kansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Kansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Kansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Kansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Kansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Kansas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,4
+Kentucky,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+Kentucky,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+Kentucky,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+Kentucky,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+Kentucky,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+Kentucky,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+Kentucky,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+Kentucky,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+Kentucky,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+Kentucky,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+Kentucky,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+Kentucky,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+Kentucky,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+Kentucky,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+Kentucky,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+Kentucky,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+Kentucky,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+Kentucky,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+Kentucky,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+Kentucky,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,0
+Kentucky,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,0
+Kentucky,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,0
+Kentucky,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,1
+Kentucky,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Kentucky,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Kentucky,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Kentucky,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Kentucky,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Kentucky,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Kentucky,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Kentucky,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Kentucky,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Kentucky,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Kentucky,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Kentucky,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Kentucky,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Kentucky,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Kentucky,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Kentucky,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Kentucky,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Kentucky,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Kentucky,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Kentucky,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Kentucky,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Kentucky,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,3
+Kentucky,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,7
+Kentucky,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Kentucky,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Kentucky,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Kentucky,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Kentucky,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Kentucky,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Kentucky,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Kentucky,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Kentucky,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Kentucky,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Kentucky,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Kentucky,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Kentucky,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Kentucky,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+Kentucky,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+Kentucky,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+Kentucky,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+Kentucky,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,1
+Kentucky,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,2
+Kentucky,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,4
+Kentucky,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,8
+Kentucky,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,17
+Kentucky,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,43
+Kentucky,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Kentucky,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Kentucky,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Kentucky,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Kentucky,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Kentucky,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Kentucky,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Kentucky,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+Kentucky,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+Kentucky,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,1
+Kentucky,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,1
+Kentucky,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,1
+Kentucky,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,2
+Kentucky,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,2
+Kentucky,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,3
+Kentucky,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,3
+Kentucky,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,5
+Kentucky,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,6
+Kentucky,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,9
+Kentucky,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,14
+Kentucky,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,30
+Kentucky,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,59
+Kentucky,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,146
+Kentucky,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Kentucky,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Kentucky,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Kentucky,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Kentucky,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Kentucky,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Kentucky,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Kentucky,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Kentucky,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+Kentucky,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+Kentucky,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,1
+Kentucky,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,1
+Kentucky,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,1
+Kentucky,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,2
+Kentucky,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,2
+Kentucky,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,3
+Kentucky,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,4
+Kentucky,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,5
+Kentucky,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,7
+Kentucky,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,12
+Kentucky,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,25
+Kentucky,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,50
+Kentucky,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,122
+Kentucky,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Kentucky,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Kentucky,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Kentucky,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Kentucky,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Kentucky,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Kentucky,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Kentucky,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Kentucky,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Kentucky,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Kentucky,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Kentucky,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Kentucky,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Kentucky,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Kentucky,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Kentucky,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Kentucky,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Kentucky,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Kentucky,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+Kentucky,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,2
+Kentucky,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,5
+Kentucky,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,11
+Kentucky,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,28
+Kentucky,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Kentucky,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Kentucky,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Kentucky,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Kentucky,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Kentucky,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Kentucky,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Kentucky,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Kentucky,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Kentucky,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Kentucky,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Kentucky,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Kentucky,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Kentucky,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Kentucky,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Kentucky,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Kentucky,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Kentucky,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Kentucky,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Kentucky,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Kentucky,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Kentucky,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,1
+Kentucky,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,4
+Kentucky,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Kentucky,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Kentucky,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Kentucky,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Kentucky,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Kentucky,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Kentucky,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Kentucky,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Kentucky,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Kentucky,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Kentucky,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Kentucky,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Kentucky,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Kentucky,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Kentucky,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Kentucky,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Kentucky,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Kentucky,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Kentucky,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Kentucky,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Kentucky,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Kentucky,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Kentucky,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,1
+Louisiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+Louisiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+Louisiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+Louisiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+Louisiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+Louisiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+Louisiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+Louisiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+Louisiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+Louisiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+Louisiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+Louisiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+Louisiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+Louisiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+Louisiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+Louisiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+Louisiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+Louisiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+Louisiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,1
+Louisiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,1
+Louisiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,3
+Louisiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,7
+Louisiana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,18
+Louisiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Louisiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Louisiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Louisiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Louisiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Louisiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Louisiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Louisiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Louisiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Louisiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Louisiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Louisiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Louisiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Louisiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,1
+Louisiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,1
+Louisiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,1
+Louisiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,2
+Louisiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,3
+Louisiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,4
+Louisiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,7
+Louisiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,14
+Louisiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,29
+Louisiana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,72
+Louisiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Louisiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Louisiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Louisiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Louisiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,1
+Louisiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,1
+Louisiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,1
+Louisiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,2
+Louisiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,2
+Louisiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,3
+Louisiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,4
+Louisiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,5
+Louisiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,6
+Louisiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,7
+Louisiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,9
+Louisiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,11
+Louisiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,14
+Louisiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,19
+Louisiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,27
+Louisiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,42
+Louisiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,88
+Louisiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,175
+Louisiana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,430
+Louisiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Louisiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Louisiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,1
+Louisiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,2
+Louisiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,3
+Louisiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,5
+Louisiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,6
+Louisiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,8
+Louisiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,10
+Louisiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,12
+Louisiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,15
+Louisiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,18
+Louisiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,22
+Louisiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,27
+Louisiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,33
+Louisiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,40
+Louisiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,51
+Louisiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,68
+Louisiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,95
+Louisiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,147
+Louisiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,302
+Louisiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,603
+Louisiana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,1474
+Louisiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Louisiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Louisiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,1
+Louisiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,2
+Louisiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,3
+Louisiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,4
+Louisiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,5
+Louisiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,7
+Louisiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,8
+Louisiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,10
+Louisiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,13
+Louisiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,15
+Louisiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,18
+Louisiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,22
+Louisiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,27
+Louisiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,34
+Louisiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,43
+Louisiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,57
+Louisiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,80
+Louisiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,124
+Louisiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,254
+Louisiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,506
+Louisiana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,1236
+Louisiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Louisiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Louisiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Louisiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Louisiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Louisiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Louisiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,1
+Louisiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,1
+Louisiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,1
+Louisiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,2
+Louisiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,2
+Louisiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,3
+Louisiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,4
+Louisiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,5
+Louisiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,6
+Louisiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,7
+Louisiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,9
+Louisiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,12
+Louisiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,17
+Louisiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,27
+Louisiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,57
+Louisiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,113
+Louisiana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,278
+Louisiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Louisiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Louisiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Louisiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Louisiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Louisiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Louisiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Louisiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Louisiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Louisiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Louisiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Louisiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Louisiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Louisiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Louisiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Louisiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,1
+Louisiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,1
+Louisiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,1
+Louisiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,2
+Louisiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,4
+Louisiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,9
+Louisiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,18
+Louisiana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,45
+Louisiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Louisiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Louisiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Louisiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Louisiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Louisiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Louisiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Louisiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Louisiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Louisiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Louisiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Louisiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Louisiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Louisiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Louisiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Louisiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Louisiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Louisiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Louisiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Louisiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,1
+Louisiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,2
+Louisiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,4
+Louisiana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,12
+Maine,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+Maine,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+Maine,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+Maine,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+Maine,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+Maine,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+Maine,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+Maine,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+Maine,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+Maine,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+Maine,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+Maine,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+Maine,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+Maine,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+Maine,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+Maine,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+Maine,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+Maine,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+Maine,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+Maine,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,0
+Maine,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,0
+Maine,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,0
+Maine,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,0
+Maine,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Maine,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Maine,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Maine,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Maine,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Maine,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Maine,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Maine,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Maine,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Maine,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Maine,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Maine,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Maine,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Maine,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Maine,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Maine,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Maine,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Maine,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Maine,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Maine,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Maine,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Maine,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+Maine,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,0
+Maine,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Maine,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Maine,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Maine,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Maine,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Maine,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Maine,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Maine,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Maine,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Maine,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Maine,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Maine,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Maine,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Maine,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+Maine,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+Maine,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,0
+Maine,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,0
+Maine,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,0
+Maine,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,0
+Maine,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,0
+Maine,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,0
+Maine,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,1
+Maine,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,3
+Maine,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Maine,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Maine,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Maine,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Maine,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Maine,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Maine,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Maine,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+Maine,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+Maine,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,0
+Maine,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,0
+Maine,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,0
+Maine,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,0
+Maine,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,0
+Maine,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,0
+Maine,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,0
+Maine,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,0
+Maine,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,0
+Maine,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,0
+Maine,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,1
+Maine,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,2
+Maine,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,5
+Maine,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,12
+Maine,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Maine,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Maine,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Maine,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Maine,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Maine,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Maine,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Maine,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Maine,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+Maine,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+Maine,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,0
+Maine,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,0
+Maine,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,0
+Maine,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,0
+Maine,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,0
+Maine,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,0
+Maine,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,0
+Maine,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,0
+Maine,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,0
+Maine,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,1
+Maine,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,2
+Maine,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,4
+Maine,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,10
+Maine,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Maine,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Maine,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Maine,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Maine,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Maine,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Maine,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Maine,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Maine,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Maine,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Maine,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Maine,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Maine,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Maine,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Maine,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Maine,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Maine,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Maine,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+Maine,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,0
+Maine,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,0
+Maine,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,0
+Maine,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,0
+Maine,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,2
+Maine,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Maine,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Maine,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Maine,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Maine,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Maine,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Maine,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Maine,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Maine,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Maine,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Maine,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Maine,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Maine,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Maine,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Maine,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Maine,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Maine,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Maine,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Maine,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Maine,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Maine,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Maine,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Maine,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+Maine,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Maine,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Maine,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Maine,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Maine,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Maine,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Maine,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Maine,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Maine,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Maine,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Maine,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Maine,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Maine,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Maine,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Maine,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Maine,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Maine,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Maine,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Maine,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Maine,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Maine,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Maine,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Maine,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Maryland,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+Maryland,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+Maryland,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+Maryland,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+Maryland,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+Maryland,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+Maryland,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+Maryland,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+Maryland,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+Maryland,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+Maryland,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+Maryland,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+Maryland,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+Maryland,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+Maryland,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+Maryland,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+Maryland,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+Maryland,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+Maryland,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+Maryland,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,0
+Maryland,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,0
+Maryland,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,1
+Maryland,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,3
+Maryland,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Maryland,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Maryland,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Maryland,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Maryland,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Maryland,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Maryland,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Maryland,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Maryland,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Maryland,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Maryland,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Maryland,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Maryland,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Maryland,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Maryland,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Maryland,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Maryland,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Maryland,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Maryland,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Maryland,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Maryland,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,2
+Maryland,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,5
+Maryland,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,14
+Maryland,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Maryland,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Maryland,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Maryland,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Maryland,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Maryland,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Maryland,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Maryland,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Maryland,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Maryland,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Maryland,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Maryland,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Maryland,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Maryland,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+Maryland,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+Maryland,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,2
+Maryland,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,2
+Maryland,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,3
+Maryland,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,5
+Maryland,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,8
+Maryland,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,16
+Maryland,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,33
+Maryland,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,82
+Maryland,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Maryland,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Maryland,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Maryland,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Maryland,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Maryland,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Maryland,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,1
+Maryland,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,1
+Maryland,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,1
+Maryland,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,2
+Maryland,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,2
+Maryland,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,3
+Maryland,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,4
+Maryland,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,5
+Maryland,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,6
+Maryland,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,7
+Maryland,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,9
+Maryland,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,12
+Maryland,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,17
+Maryland,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,27
+Maryland,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,57
+Maryland,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,114
+Maryland,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,280
+Maryland,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Maryland,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Maryland,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Maryland,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Maryland,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Maryland,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Maryland,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,1
+Maryland,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+Maryland,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,1
+Maryland,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,1
+Maryland,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,2
+Maryland,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,2
+Maryland,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,3
+Maryland,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,4
+Maryland,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,5
+Maryland,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,6
+Maryland,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,8
+Maryland,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,10
+Maryland,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,15
+Maryland,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,23
+Maryland,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,48
+Maryland,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,96
+Maryland,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,235
+Maryland,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Maryland,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Maryland,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Maryland,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Maryland,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Maryland,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Maryland,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Maryland,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Maryland,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Maryland,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Maryland,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Maryland,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Maryland,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Maryland,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Maryland,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Maryland,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Maryland,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Maryland,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,2
+Maryland,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,3
+Maryland,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,5
+Maryland,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,10
+Maryland,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,21
+Maryland,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,53
+Maryland,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Maryland,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Maryland,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Maryland,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Maryland,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Maryland,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Maryland,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Maryland,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Maryland,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Maryland,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Maryland,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Maryland,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Maryland,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Maryland,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Maryland,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Maryland,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Maryland,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Maryland,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Maryland,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Maryland,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Maryland,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,1
+Maryland,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,3
+Maryland,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,8
+Maryland,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Maryland,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Maryland,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Maryland,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Maryland,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Maryland,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Maryland,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Maryland,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Maryland,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Maryland,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Maryland,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Maryland,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Maryland,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Maryland,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Maryland,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Maryland,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Maryland,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Maryland,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Maryland,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Maryland,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Maryland,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Maryland,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Maryland,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,2
+Massachusetts,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+Massachusetts,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+Massachusetts,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+Massachusetts,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+Massachusetts,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+Massachusetts,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+Massachusetts,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+Massachusetts,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+Massachusetts,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+Massachusetts,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+Massachusetts,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+Massachusetts,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+Massachusetts,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+Massachusetts,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+Massachusetts,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+Massachusetts,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+Massachusetts,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+Massachusetts,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+Massachusetts,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+Massachusetts,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,0
+Massachusetts,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,0
+Massachusetts,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,0
+Massachusetts,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,2
+Massachusetts,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Massachusetts,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Massachusetts,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Massachusetts,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Massachusetts,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Massachusetts,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Massachusetts,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Massachusetts,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Massachusetts,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Massachusetts,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Massachusetts,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Massachusetts,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Massachusetts,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Massachusetts,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Massachusetts,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Massachusetts,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Massachusetts,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Massachusetts,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Massachusetts,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Massachusetts,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Massachusetts,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Massachusetts,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,3
+Massachusetts,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,9
+Massachusetts,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Massachusetts,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Massachusetts,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Massachusetts,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Massachusetts,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Massachusetts,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Massachusetts,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Massachusetts,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Massachusetts,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Massachusetts,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Massachusetts,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Massachusetts,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Massachusetts,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Massachusetts,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+Massachusetts,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+Massachusetts,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+Massachusetts,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+Massachusetts,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,2
+Massachusetts,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,3
+Massachusetts,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,5
+Massachusetts,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,11
+Massachusetts,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,22
+Massachusetts,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,56
+Massachusetts,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Massachusetts,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Massachusetts,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Massachusetts,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Massachusetts,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Massachusetts,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Massachusetts,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Massachusetts,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,1
+Massachusetts,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,1
+Massachusetts,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,1
+Massachusetts,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,1
+Massachusetts,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,2
+Massachusetts,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,2
+Massachusetts,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,3
+Massachusetts,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,4
+Massachusetts,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,5
+Massachusetts,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,6
+Massachusetts,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,8
+Massachusetts,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,12
+Massachusetts,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,18
+Massachusetts,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,38
+Massachusetts,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,77
+Massachusetts,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,190
+Massachusetts,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Massachusetts,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Massachusetts,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Massachusetts,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Massachusetts,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Massachusetts,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Massachusetts,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Massachusetts,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Massachusetts,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,1
+Massachusetts,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,1
+Massachusetts,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,1
+Massachusetts,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,1
+Massachusetts,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,2
+Massachusetts,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,2
+Massachusetts,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,3
+Massachusetts,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,4
+Massachusetts,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,5
+Massachusetts,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,7
+Massachusetts,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,10
+Massachusetts,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,15
+Massachusetts,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,32
+Massachusetts,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,65
+Massachusetts,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,160
+Massachusetts,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Massachusetts,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Massachusetts,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Massachusetts,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Massachusetts,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Massachusetts,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Massachusetts,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Massachusetts,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Massachusetts,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Massachusetts,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Massachusetts,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Massachusetts,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Massachusetts,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Massachusetts,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Massachusetts,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Massachusetts,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Massachusetts,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Massachusetts,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Massachusetts,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,2
+Massachusetts,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,3
+Massachusetts,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,7
+Massachusetts,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,14
+Massachusetts,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,36
+Massachusetts,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Massachusetts,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Massachusetts,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Massachusetts,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Massachusetts,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Massachusetts,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Massachusetts,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Massachusetts,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Massachusetts,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Massachusetts,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Massachusetts,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Massachusetts,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Massachusetts,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Massachusetts,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Massachusetts,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Massachusetts,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Massachusetts,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Massachusetts,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Massachusetts,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Massachusetts,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Massachusetts,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,1
+Massachusetts,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,2
+Massachusetts,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,6
+Massachusetts,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Massachusetts,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Massachusetts,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Massachusetts,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Massachusetts,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Massachusetts,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Massachusetts,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Massachusetts,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Massachusetts,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Massachusetts,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Massachusetts,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Massachusetts,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Massachusetts,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Massachusetts,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Massachusetts,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Massachusetts,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Massachusetts,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Massachusetts,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Massachusetts,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Massachusetts,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Massachusetts,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Massachusetts,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Massachusetts,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,1
+Michigan,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+Michigan,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+Michigan,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+Michigan,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+Michigan,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+Michigan,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+Michigan,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+Michigan,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+Michigan,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+Michigan,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+Michigan,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+Michigan,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+Michigan,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+Michigan,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+Michigan,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+Michigan,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+Michigan,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+Michigan,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+Michigan,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+Michigan,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,0
+Michigan,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,1
+Michigan,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,2
+Michigan,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,6
+Michigan,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Michigan,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Michigan,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Michigan,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Michigan,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Michigan,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Michigan,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Michigan,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Michigan,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Michigan,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Michigan,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Michigan,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Michigan,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Michigan,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Michigan,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Michigan,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Michigan,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Michigan,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Michigan,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Michigan,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,2
+Michigan,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,4
+Michigan,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,9
+Michigan,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,23
+Michigan,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Michigan,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Michigan,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Michigan,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Michigan,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Michigan,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Michigan,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Michigan,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Michigan,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Michigan,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+Michigan,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Michigan,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Michigan,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Michigan,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,2
+Michigan,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+Michigan,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,3
+Michigan,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,4
+Michigan,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,6
+Michigan,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,8
+Michigan,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,13
+Michigan,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,28
+Michigan,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,57
+Michigan,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,140
+Michigan,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Michigan,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Michigan,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Michigan,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Michigan,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,1
+Michigan,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+Michigan,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,2
+Michigan,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,2
+Michigan,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,3
+Michigan,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,4
+Michigan,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,4
+Michigan,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,5
+Michigan,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,7
+Michigan,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,8
+Michigan,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,10
+Michigan,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,13
+Michigan,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,16
+Michigan,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,21
+Michigan,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,30
+Michigan,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,47
+Michigan,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,97
+Michigan,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,195
+Michigan,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,478
+Michigan,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Michigan,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Michigan,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Michigan,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Michigan,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Michigan,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,1
+Michigan,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,1
+Michigan,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,2
+Michigan,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,2
+Michigan,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,3
+Michigan,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,4
+Michigan,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,4
+Michigan,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,5
+Michigan,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,7
+Michigan,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,8
+Michigan,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,10
+Michigan,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,13
+Michigan,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,18
+Michigan,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,25
+Michigan,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,40
+Michigan,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,82
+Michigan,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,164
+Michigan,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,401
+Michigan,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Michigan,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Michigan,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Michigan,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Michigan,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Michigan,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Michigan,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Michigan,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Michigan,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Michigan,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Michigan,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Michigan,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,1
+Michigan,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+Michigan,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Michigan,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Michigan,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,2
+Michigan,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,3
+Michigan,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,4
+Michigan,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,5
+Michigan,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,8
+Michigan,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,18
+Michigan,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,37
+Michigan,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,91
+Michigan,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Michigan,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Michigan,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Michigan,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Michigan,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Michigan,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Michigan,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Michigan,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Michigan,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Michigan,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Michigan,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Michigan,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Michigan,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Michigan,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Michigan,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Michigan,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Michigan,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Michigan,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Michigan,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Michigan,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Michigan,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,2
+Michigan,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,6
+Michigan,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,15
+Michigan,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Michigan,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Michigan,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Michigan,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Michigan,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Michigan,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Michigan,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Michigan,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Michigan,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Michigan,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Michigan,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Michigan,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Michigan,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Michigan,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Michigan,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Michigan,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Michigan,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Michigan,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Michigan,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Michigan,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Michigan,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Michigan,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Michigan,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,3
+Minnesota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+Minnesota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+Minnesota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+Minnesota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+Minnesota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+Minnesota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+Minnesota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+Minnesota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+Minnesota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+Minnesota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+Minnesota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+Minnesota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+Minnesota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+Minnesota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+Minnesota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+Minnesota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+Minnesota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+Minnesota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+Minnesota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+Minnesota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,0
+Minnesota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,0
+Minnesota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,1
+Minnesota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,4
+Minnesota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Minnesota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Minnesota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Minnesota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Minnesota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Minnesota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Minnesota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Minnesota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Minnesota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Minnesota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Minnesota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Minnesota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Minnesota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Minnesota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Minnesota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Minnesota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Minnesota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Minnesota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Minnesota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Minnesota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Minnesota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,3
+Minnesota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,7
+Minnesota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,18
+Minnesota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Minnesota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Minnesota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Minnesota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Minnesota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Minnesota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Minnesota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Minnesota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Minnesota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Minnesota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Minnesota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Minnesota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Minnesota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Minnesota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+Minnesota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+Minnesota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,2
+Minnesota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,3
+Minnesota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,4
+Minnesota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,6
+Minnesota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,10
+Minnesota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,21
+Minnesota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,43
+Minnesota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,107
+Minnesota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Minnesota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Minnesota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Minnesota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Minnesota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Minnesota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+Minnesota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,1
+Minnesota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,2
+Minnesota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,2
+Minnesota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,3
+Minnesota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,3
+Minnesota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,4
+Minnesota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,5
+Minnesota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,6
+Minnesota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,8
+Minnesota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,9
+Minnesota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,12
+Minnesota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,16
+Minnesota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,23
+Minnesota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,36
+Minnesota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,74
+Minnesota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,148
+Minnesota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,364
+Minnesota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Minnesota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Minnesota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Minnesota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Minnesota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Minnesota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,1
+Minnesota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,1
+Minnesota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+Minnesota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,2
+Minnesota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,2
+Minnesota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,3
+Minnesota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,3
+Minnesota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,4
+Minnesota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,5
+Minnesota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,6
+Minnesota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,8
+Minnesota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,10
+Minnesota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,14
+Minnesota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,19
+Minnesota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,30
+Minnesota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,62
+Minnesota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,125
+Minnesota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,305
+Minnesota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Minnesota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Minnesota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Minnesota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Minnesota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Minnesota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Minnesota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Minnesota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Minnesota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Minnesota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Minnesota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Minnesota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Minnesota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Minnesota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Minnesota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Minnesota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Minnesota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,2
+Minnesota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,3
+Minnesota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,4
+Minnesota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,6
+Minnesota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,14
+Minnesota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,28
+Minnesota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,69
+Minnesota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Minnesota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Minnesota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Minnesota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Minnesota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Minnesota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Minnesota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Minnesota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Minnesota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Minnesota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Minnesota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Minnesota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Minnesota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Minnesota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Minnesota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Minnesota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Minnesota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Minnesota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Minnesota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Minnesota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Minnesota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,2
+Minnesota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,4
+Minnesota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,11
+Minnesota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Minnesota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Minnesota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Minnesota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Minnesota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Minnesota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Minnesota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Minnesota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Minnesota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Minnesota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Minnesota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Minnesota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Minnesota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Minnesota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Minnesota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Minnesota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Minnesota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Minnesota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Minnesota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Minnesota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Minnesota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Minnesota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Minnesota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,2
+Mississippi,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+Mississippi,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+Mississippi,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+Mississippi,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+Mississippi,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+Mississippi,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+Mississippi,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+Mississippi,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+Mississippi,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+Mississippi,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+Mississippi,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+Mississippi,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+Mississippi,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+Mississippi,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+Mississippi,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+Mississippi,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+Mississippi,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+Mississippi,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+Mississippi,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+Mississippi,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,1
+Mississippi,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,2
+Mississippi,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,5
+Mississippi,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,12
+Mississippi,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Mississippi,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Mississippi,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Mississippi,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Mississippi,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Mississippi,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Mississippi,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Mississippi,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Mississippi,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Mississippi,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Mississippi,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Mississippi,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Mississippi,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Mississippi,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Mississippi,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,1
+Mississippi,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,1
+Mississippi,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,1
+Mississippi,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,2
+Mississippi,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,3
+Mississippi,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,4
+Mississippi,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,10
+Mississippi,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,20
+Mississippi,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,50
+Mississippi,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Mississippi,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Mississippi,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Mississippi,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Mississippi,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Mississippi,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Mississippi,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,1
+Mississippi,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,1
+Mississippi,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,2
+Mississippi,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,2
+Mississippi,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,3
+Mississippi,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,3
+Mississippi,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,4
+Mississippi,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,5
+Mississippi,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,6
+Mississippi,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,8
+Mississippi,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,10
+Mississippi,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,13
+Mississippi,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,19
+Mississippi,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,29
+Mississippi,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,60
+Mississippi,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,121
+Mississippi,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,295
+Mississippi,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Mississippi,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Mississippi,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Mississippi,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,1
+Mississippi,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,2
+Mississippi,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,3
+Mississippi,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,4
+Mississippi,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,5
+Mississippi,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,7
+Mississippi,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,8
+Mississippi,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,10
+Mississippi,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,12
+Mississippi,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,15
+Mississippi,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,18
+Mississippi,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,22
+Mississippi,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,28
+Mississippi,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,36
+Mississippi,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,47
+Mississippi,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,65
+Mississippi,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,102
+Mississippi,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,209
+Mississippi,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,415
+Mississippi,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,1011
+Mississippi,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Mississippi,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Mississippi,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Mississippi,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,1
+Mississippi,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,2
+Mississippi,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,3
+Mississippi,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,4
+Mississippi,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,5
+Mississippi,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,6
+Mississippi,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,7
+Mississippi,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,9
+Mississippi,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,10
+Mississippi,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,13
+Mississippi,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,15
+Mississippi,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,19
+Mississippi,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,23
+Mississippi,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,30
+Mississippi,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,39
+Mississippi,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,55
+Mississippi,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,86
+Mississippi,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,175
+Mississippi,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,348
+Mississippi,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,847
+Mississippi,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Mississippi,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Mississippi,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Mississippi,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Mississippi,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Mississippi,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Mississippi,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Mississippi,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,1
+Mississippi,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,1
+Mississippi,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,1
+Mississippi,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,1
+Mississippi,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,2
+Mississippi,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,2
+Mississippi,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,3
+Mississippi,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,4
+Mississippi,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,5
+Mississippi,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,6
+Mississippi,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,8
+Mississippi,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,12
+Mississippi,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,19
+Mississippi,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,39
+Mississippi,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,78
+Mississippi,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,191
+Mississippi,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Mississippi,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Mississippi,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Mississippi,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Mississippi,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Mississippi,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Mississippi,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Mississippi,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Mississippi,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Mississippi,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Mississippi,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Mississippi,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Mississippi,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Mississippi,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Mississippi,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Mississippi,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Mississippi,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,1
+Mississippi,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,1
+Mississippi,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,1
+Mississippi,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,3
+Mississippi,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,6
+Mississippi,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,12
+Mississippi,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,31
+Mississippi,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Mississippi,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Mississippi,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Mississippi,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Mississippi,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Mississippi,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Mississippi,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Mississippi,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Mississippi,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Mississippi,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Mississippi,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Mississippi,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Mississippi,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Mississippi,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Mississippi,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Mississippi,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Mississippi,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Mississippi,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Mississippi,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Mississippi,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Mississippi,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,1
+Mississippi,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,3
+Mississippi,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,8
+Missouri,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+Missouri,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+Missouri,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+Missouri,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+Missouri,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+Missouri,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+Missouri,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+Missouri,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+Missouri,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+Missouri,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+Missouri,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+Missouri,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+Missouri,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+Missouri,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+Missouri,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+Missouri,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+Missouri,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+Missouri,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+Missouri,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+Missouri,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,0
+Missouri,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,1
+Missouri,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,2
+Missouri,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,5
+Missouri,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Missouri,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Missouri,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Missouri,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Missouri,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Missouri,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Missouri,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Missouri,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Missouri,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Missouri,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Missouri,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Missouri,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Missouri,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Missouri,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Missouri,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Missouri,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Missouri,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Missouri,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Missouri,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Missouri,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,2
+Missouri,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,4
+Missouri,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,9
+Missouri,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,23
+Missouri,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Missouri,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Missouri,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Missouri,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Missouri,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Missouri,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Missouri,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Missouri,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Missouri,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Missouri,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+Missouri,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Missouri,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Missouri,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Missouri,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,2
+Missouri,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+Missouri,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,3
+Missouri,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,4
+Missouri,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,6
+Missouri,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,8
+Missouri,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,13
+Missouri,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,27
+Missouri,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,55
+Missouri,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,135
+Missouri,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Missouri,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Missouri,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Missouri,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Missouri,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,1
+Missouri,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+Missouri,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,2
+Missouri,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,2
+Missouri,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,3
+Missouri,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,3
+Missouri,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,4
+Missouri,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,5
+Missouri,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,6
+Missouri,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,8
+Missouri,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,10
+Missouri,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,12
+Missouri,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,16
+Missouri,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,21
+Missouri,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,29
+Missouri,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,46
+Missouri,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,94
+Missouri,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,188
+Missouri,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,459
+Missouri,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Missouri,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Missouri,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Missouri,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Missouri,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Missouri,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,1
+Missouri,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,1
+Missouri,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,2
+Missouri,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,2
+Missouri,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,3
+Missouri,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,3
+Missouri,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,4
+Missouri,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,5
+Missouri,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,7
+Missouri,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,8
+Missouri,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,10
+Missouri,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,13
+Missouri,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,17
+Missouri,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,24
+Missouri,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,38
+Missouri,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,79
+Missouri,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,158
+Missouri,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,385
+Missouri,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Missouri,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Missouri,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Missouri,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Missouri,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Missouri,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Missouri,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Missouri,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Missouri,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Missouri,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Missouri,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Missouri,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,1
+Missouri,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+Missouri,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Missouri,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Missouri,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,2
+Missouri,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,2
+Missouri,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,3
+Missouri,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,5
+Missouri,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,8
+Missouri,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,17
+Missouri,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,35
+Missouri,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,87
+Missouri,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Missouri,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Missouri,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Missouri,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Missouri,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Missouri,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Missouri,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Missouri,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Missouri,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Missouri,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Missouri,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Missouri,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Missouri,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Missouri,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Missouri,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Missouri,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Missouri,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Missouri,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Missouri,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Missouri,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Missouri,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,2
+Missouri,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,5
+Missouri,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,14
+Missouri,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Missouri,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Missouri,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Missouri,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Missouri,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Missouri,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Missouri,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Missouri,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Missouri,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Missouri,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Missouri,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Missouri,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Missouri,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Missouri,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Missouri,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Missouri,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Missouri,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Missouri,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Missouri,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Missouri,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Missouri,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Missouri,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Missouri,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,3
+Montana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+Montana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+Montana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+Montana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+Montana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+Montana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+Montana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+Montana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+Montana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+Montana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+Montana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+Montana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+Montana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+Montana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+Montana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+Montana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+Montana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+Montana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+Montana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+Montana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,0
+Montana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,0
+Montana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,0
+Montana,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,1
+Montana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Montana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Montana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Montana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Montana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Montana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Montana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Montana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Montana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Montana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Montana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Montana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Montana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Montana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Montana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Montana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Montana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Montana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Montana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Montana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Montana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Montana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,2
+Montana,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,6
+Montana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Montana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Montana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Montana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Montana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Montana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Montana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Montana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Montana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Montana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Montana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Montana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Montana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Montana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+Montana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+Montana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,0
+Montana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+Montana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,1
+Montana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,2
+Montana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,3
+Montana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,7
+Montana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,14
+Montana,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,35
+Montana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Montana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Montana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Montana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Montana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Montana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Montana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Montana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+Montana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+Montana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,0
+Montana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,1
+Montana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,1
+Montana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,1
+Montana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,2
+Montana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,2
+Montana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,3
+Montana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,4
+Montana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,5
+Montana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,7
+Montana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,11
+Montana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,24
+Montana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,48
+Montana,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,119
+Montana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Montana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Montana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Montana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Montana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Montana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Montana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Montana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Montana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+Montana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+Montana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,0
+Montana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,1
+Montana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,1
+Montana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,1
+Montana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,2
+Montana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,2
+Montana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,3
+Montana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,4
+Montana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,6
+Montana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,9
+Montana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,20
+Montana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,40
+Montana,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,100
+Montana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Montana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Montana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Montana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Montana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Montana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Montana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Montana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Montana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Montana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Montana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Montana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Montana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Montana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Montana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Montana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Montana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Montana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+Montana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+Montana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,2
+Montana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,4
+Montana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,9
+Montana,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,23
+Montana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Montana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Montana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Montana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Montana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Montana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Montana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Montana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Montana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Montana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Montana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Montana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Montana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Montana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Montana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Montana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Montana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Montana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Montana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Montana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Montana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Montana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,1
+Montana,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,3
+Montana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Montana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Montana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Montana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Montana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Montana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Montana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Montana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Montana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Montana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Montana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Montana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Montana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Montana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Montana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Montana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Montana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Montana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Montana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Montana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Montana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Montana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Montana,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Nebraska,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+Nebraska,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+Nebraska,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+Nebraska,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+Nebraska,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+Nebraska,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+Nebraska,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+Nebraska,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+Nebraska,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+Nebraska,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+Nebraska,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+Nebraska,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+Nebraska,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+Nebraska,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+Nebraska,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+Nebraska,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+Nebraska,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+Nebraska,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+Nebraska,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+Nebraska,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,0
+Nebraska,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,1
+Nebraska,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,3
+Nebraska,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,9
+Nebraska,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Nebraska,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Nebraska,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Nebraska,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Nebraska,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Nebraska,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Nebraska,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Nebraska,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Nebraska,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Nebraska,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Nebraska,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Nebraska,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Nebraska,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Nebraska,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Nebraska,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Nebraska,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Nebraska,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,1
+Nebraska,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,1
+Nebraska,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,2
+Nebraska,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,3
+Nebraska,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,7
+Nebraska,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,14
+Nebraska,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,35
+Nebraska,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Nebraska,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Nebraska,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Nebraska,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Nebraska,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Nebraska,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Nebraska,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Nebraska,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,1
+Nebraska,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,1
+Nebraska,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+Nebraska,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,2
+Nebraska,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,2
+Nebraska,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,2
+Nebraska,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,3
+Nebraska,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,4
+Nebraska,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,5
+Nebraska,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,7
+Nebraska,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,9
+Nebraska,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,13
+Nebraska,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,20
+Nebraska,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,42
+Nebraska,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,84
+Nebraska,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,207
+Nebraska,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Nebraska,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Nebraska,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Nebraska,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,1
+Nebraska,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,1
+Nebraska,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,2
+Nebraska,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,3
+Nebraska,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,4
+Nebraska,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,4
+Nebraska,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,6
+Nebraska,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,7
+Nebraska,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,8
+Nebraska,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,10
+Nebraska,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,12
+Nebraska,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,15
+Nebraska,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,19
+Nebraska,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,24
+Nebraska,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,32
+Nebraska,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,45
+Nebraska,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,70
+Nebraska,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,145
+Nebraska,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,289
+Nebraska,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,708
+Nebraska,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Nebraska,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Nebraska,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Nebraska,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Nebraska,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,1
+Nebraska,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,2
+Nebraska,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,2
+Nebraska,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,3
+Nebraska,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,4
+Nebraska,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,5
+Nebraska,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,6
+Nebraska,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,7
+Nebraska,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,8
+Nebraska,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,10
+Nebraska,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,13
+Nebraska,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,16
+Nebraska,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,20
+Nebraska,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,27
+Nebraska,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,38
+Nebraska,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,59
+Nebraska,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,122
+Nebraska,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,243
+Nebraska,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,594
+Nebraska,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Nebraska,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Nebraska,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Nebraska,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Nebraska,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Nebraska,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Nebraska,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Nebraska,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Nebraska,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Nebraska,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,1
+Nebraska,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,1
+Nebraska,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,1
+Nebraska,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+Nebraska,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,2
+Nebraska,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,2
+Nebraska,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,3
+Nebraska,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,4
+Nebraska,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,6
+Nebraska,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,8
+Nebraska,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,13
+Nebraska,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,27
+Nebraska,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,54
+Nebraska,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,134
+Nebraska,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Nebraska,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Nebraska,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Nebraska,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Nebraska,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Nebraska,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Nebraska,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Nebraska,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Nebraska,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Nebraska,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Nebraska,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Nebraska,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Nebraska,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Nebraska,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Nebraska,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Nebraska,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Nebraska,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Nebraska,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Nebraska,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,1
+Nebraska,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,2
+Nebraska,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,4
+Nebraska,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,8
+Nebraska,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,22
+Nebraska,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Nebraska,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Nebraska,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Nebraska,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Nebraska,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Nebraska,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Nebraska,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Nebraska,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Nebraska,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Nebraska,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Nebraska,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Nebraska,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Nebraska,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Nebraska,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Nebraska,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Nebraska,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Nebraska,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Nebraska,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Nebraska,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Nebraska,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Nebraska,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,1
+Nebraska,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,2
+Nebraska,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,5
+Nevada,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+Nevada,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+Nevada,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+Nevada,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+Nevada,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+Nevada,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+Nevada,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+Nevada,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+Nevada,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+Nevada,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+Nevada,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+Nevada,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+Nevada,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+Nevada,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+Nevada,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+Nevada,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+Nevada,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+Nevada,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+Nevada,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+Nevada,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,0
+Nevada,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,0
+Nevada,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,1
+Nevada,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,2
+Nevada,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Nevada,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Nevada,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Nevada,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Nevada,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Nevada,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Nevada,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Nevada,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Nevada,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Nevada,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Nevada,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Nevada,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Nevada,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Nevada,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Nevada,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Nevada,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Nevada,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Nevada,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Nevada,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Nevada,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Nevada,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,2
+Nevada,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,4
+Nevada,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,11
+Nevada,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Nevada,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Nevada,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Nevada,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Nevada,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Nevada,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Nevada,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Nevada,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Nevada,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Nevada,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Nevada,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Nevada,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Nevada,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Nevada,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+Nevada,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+Nevada,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+Nevada,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,2
+Nevada,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,2
+Nevada,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,4
+Nevada,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,6
+Nevada,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,13
+Nevada,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,26
+Nevada,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,65
+Nevada,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Nevada,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Nevada,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Nevada,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Nevada,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Nevada,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Nevada,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Nevada,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,1
+Nevada,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,1
+Nevada,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,1
+Nevada,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,2
+Nevada,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,2
+Nevada,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,3
+Nevada,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,3
+Nevada,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,4
+Nevada,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,5
+Nevada,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,7
+Nevada,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,10
+Nevada,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,14
+Nevada,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,21
+Nevada,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,45
+Nevada,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,90
+Nevada,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,220
+Nevada,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Nevada,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Nevada,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Nevada,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Nevada,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Nevada,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Nevada,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Nevada,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Nevada,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,1
+Nevada,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,1
+Nevada,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,1
+Nevada,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,2
+Nevada,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,2
+Nevada,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,3
+Nevada,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,4
+Nevada,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,5
+Nevada,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,6
+Nevada,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,8
+Nevada,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,11
+Nevada,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,18
+Nevada,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,37
+Nevada,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,75
+Nevada,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,185
+Nevada,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Nevada,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Nevada,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Nevada,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Nevada,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Nevada,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Nevada,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Nevada,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Nevada,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Nevada,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Nevada,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Nevada,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Nevada,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Nevada,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Nevada,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Nevada,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Nevada,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Nevada,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Nevada,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,2
+Nevada,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,4
+Nevada,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,8
+Nevada,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,17
+Nevada,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,42
+Nevada,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Nevada,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Nevada,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Nevada,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Nevada,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Nevada,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Nevada,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Nevada,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Nevada,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Nevada,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Nevada,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Nevada,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Nevada,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Nevada,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Nevada,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Nevada,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Nevada,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Nevada,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Nevada,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Nevada,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Nevada,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,1
+Nevada,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,2
+Nevada,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,7
+Nevada,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Nevada,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Nevada,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Nevada,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Nevada,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Nevada,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Nevada,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Nevada,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Nevada,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Nevada,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Nevada,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Nevada,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Nevada,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Nevada,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Nevada,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Nevada,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Nevada,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Nevada,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Nevada,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Nevada,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Nevada,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Nevada,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Nevada,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,1
+New Hampshire,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+New Hampshire,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+New Hampshire,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+New Hampshire,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+New Hampshire,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+New Hampshire,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+New Hampshire,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+New Hampshire,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+New Hampshire,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+New Hampshire,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+New Hampshire,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+New Hampshire,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+New Hampshire,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+New Hampshire,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+New Hampshire,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+New Hampshire,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+New Hampshire,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+New Hampshire,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+New Hampshire,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+New Hampshire,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,0
+New Hampshire,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,0
+New Hampshire,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,0
+New Hampshire,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,0
+New Hampshire,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+New Hampshire,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+New Hampshire,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+New Hampshire,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+New Hampshire,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+New Hampshire,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+New Hampshire,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+New Hampshire,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+New Hampshire,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+New Hampshire,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+New Hampshire,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+New Hampshire,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+New Hampshire,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+New Hampshire,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+New Hampshire,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+New Hampshire,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+New Hampshire,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+New Hampshire,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+New Hampshire,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+New Hampshire,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+New Hampshire,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+New Hampshire,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+New Hampshire,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,0
+New Hampshire,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+New Hampshire,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+New Hampshire,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+New Hampshire,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+New Hampshire,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+New Hampshire,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+New Hampshire,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+New Hampshire,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+New Hampshire,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+New Hampshire,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+New Hampshire,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+New Hampshire,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+New Hampshire,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+New Hampshire,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+New Hampshire,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+New Hampshire,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,0
+New Hampshire,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,0
+New Hampshire,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,0
+New Hampshire,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,0
+New Hampshire,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,0
+New Hampshire,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,0
+New Hampshire,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,1
+New Hampshire,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,2
+New Hampshire,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+New Hampshire,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+New Hampshire,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+New Hampshire,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+New Hampshire,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+New Hampshire,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+New Hampshire,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+New Hampshire,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+New Hampshire,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+New Hampshire,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,0
+New Hampshire,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,0
+New Hampshire,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,0
+New Hampshire,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,0
+New Hampshire,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,0
+New Hampshire,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,0
+New Hampshire,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,0
+New Hampshire,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,0
+New Hampshire,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,0
+New Hampshire,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,0
+New Hampshire,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,0
+New Hampshire,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,1
+New Hampshire,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,3
+New Hampshire,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,9
+New Hampshire,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+New Hampshire,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+New Hampshire,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+New Hampshire,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+New Hampshire,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+New Hampshire,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+New Hampshire,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+New Hampshire,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+New Hampshire,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+New Hampshire,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+New Hampshire,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,0
+New Hampshire,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,0
+New Hampshire,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,0
+New Hampshire,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,0
+New Hampshire,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,0
+New Hampshire,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,0
+New Hampshire,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,0
+New Hampshire,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,0
+New Hampshire,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,0
+New Hampshire,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,0
+New Hampshire,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,1
+New Hampshire,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,3
+New Hampshire,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,7
+New Hampshire,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+New Hampshire,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+New Hampshire,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+New Hampshire,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+New Hampshire,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+New Hampshire,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+New Hampshire,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+New Hampshire,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+New Hampshire,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+New Hampshire,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+New Hampshire,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+New Hampshire,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+New Hampshire,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+New Hampshire,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+New Hampshire,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+New Hampshire,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+New Hampshire,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+New Hampshire,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+New Hampshire,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,0
+New Hampshire,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,0
+New Hampshire,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,0
+New Hampshire,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,0
+New Hampshire,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,1
+New Hampshire,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+New Hampshire,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+New Hampshire,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+New Hampshire,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+New Hampshire,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+New Hampshire,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+New Hampshire,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+New Hampshire,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+New Hampshire,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+New Hampshire,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+New Hampshire,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+New Hampshire,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+New Hampshire,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+New Hampshire,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+New Hampshire,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+New Hampshire,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+New Hampshire,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+New Hampshire,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+New Hampshire,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+New Hampshire,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+New Hampshire,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+New Hampshire,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+New Hampshire,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+New Hampshire,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+New Hampshire,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+New Hampshire,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+New Hampshire,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+New Hampshire,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+New Hampshire,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+New Hampshire,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+New Hampshire,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+New Hampshire,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+New Hampshire,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+New Hampshire,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+New Hampshire,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+New Hampshire,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+New Hampshire,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+New Hampshire,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+New Hampshire,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+New Hampshire,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+New Hampshire,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+New Hampshire,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+New Hampshire,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+New Hampshire,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+New Hampshire,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+New Hampshire,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+New Jersey,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+New Jersey,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+New Jersey,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+New Jersey,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+New Jersey,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+New Jersey,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+New Jersey,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+New Jersey,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+New Jersey,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+New Jersey,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+New Jersey,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+New Jersey,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+New Jersey,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+New Jersey,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+New Jersey,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+New Jersey,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+New Jersey,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+New Jersey,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+New Jersey,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+New Jersey,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,0
+New Jersey,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,0
+New Jersey,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,1
+New Jersey,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,3
+New Jersey,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+New Jersey,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+New Jersey,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+New Jersey,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+New Jersey,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+New Jersey,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+New Jersey,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+New Jersey,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+New Jersey,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+New Jersey,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+New Jersey,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+New Jersey,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+New Jersey,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+New Jersey,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+New Jersey,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+New Jersey,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+New Jersey,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+New Jersey,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+New Jersey,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+New Jersey,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+New Jersey,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,2
+New Jersey,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,5
+New Jersey,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,14
+New Jersey,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+New Jersey,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+New Jersey,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+New Jersey,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+New Jersey,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+New Jersey,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+New Jersey,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+New Jersey,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+New Jersey,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+New Jersey,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+New Jersey,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+New Jersey,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+New Jersey,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+New Jersey,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+New Jersey,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+New Jersey,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,2
+New Jersey,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,2
+New Jersey,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,3
+New Jersey,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,5
+New Jersey,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,8
+New Jersey,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,17
+New Jersey,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,34
+New Jersey,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,84
+New Jersey,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+New Jersey,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+New Jersey,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+New Jersey,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+New Jersey,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+New Jersey,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+New Jersey,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,1
+New Jersey,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,1
+New Jersey,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,1
+New Jersey,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,2
+New Jersey,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,2
+New Jersey,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,3
+New Jersey,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,4
+New Jersey,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,5
+New Jersey,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,6
+New Jersey,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,7
+New Jersey,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,9
+New Jersey,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,13
+New Jersey,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,18
+New Jersey,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,28
+New Jersey,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,58
+New Jersey,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,116
+New Jersey,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,285
+New Jersey,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+New Jersey,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+New Jersey,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+New Jersey,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+New Jersey,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+New Jersey,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+New Jersey,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,1
+New Jersey,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+New Jersey,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,1
+New Jersey,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,1
+New Jersey,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,2
+New Jersey,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,2
+New Jersey,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,3
+New Jersey,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,4
+New Jersey,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,5
+New Jersey,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,6
+New Jersey,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,8
+New Jersey,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,11
+New Jersey,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,15
+New Jersey,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,24
+New Jersey,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,49
+New Jersey,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,98
+New Jersey,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,239
+New Jersey,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+New Jersey,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+New Jersey,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+New Jersey,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+New Jersey,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+New Jersey,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+New Jersey,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+New Jersey,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+New Jersey,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+New Jersey,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+New Jersey,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+New Jersey,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+New Jersey,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+New Jersey,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+New Jersey,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+New Jersey,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+New Jersey,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+New Jersey,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,2
+New Jersey,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,3
+New Jersey,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,5
+New Jersey,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,11
+New Jersey,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,22
+New Jersey,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,54
+New Jersey,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+New Jersey,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+New Jersey,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+New Jersey,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+New Jersey,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+New Jersey,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+New Jersey,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+New Jersey,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+New Jersey,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+New Jersey,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+New Jersey,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+New Jersey,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+New Jersey,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+New Jersey,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+New Jersey,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+New Jersey,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+New Jersey,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+New Jersey,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+New Jersey,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+New Jersey,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+New Jersey,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,1
+New Jersey,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,3
+New Jersey,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,9
+New Jersey,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+New Jersey,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+New Jersey,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+New Jersey,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+New Jersey,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+New Jersey,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+New Jersey,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+New Jersey,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+New Jersey,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+New Jersey,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+New Jersey,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+New Jersey,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+New Jersey,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+New Jersey,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+New Jersey,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+New Jersey,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+New Jersey,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+New Jersey,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+New Jersey,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+New Jersey,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+New Jersey,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+New Jersey,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+New Jersey,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,2
+New Mexico,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+New Mexico,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+New Mexico,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+New Mexico,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+New Mexico,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+New Mexico,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+New Mexico,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+New Mexico,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+New Mexico,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+New Mexico,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+New Mexico,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+New Mexico,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+New Mexico,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+New Mexico,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+New Mexico,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+New Mexico,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+New Mexico,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+New Mexico,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+New Mexico,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+New Mexico,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,0
+New Mexico,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,1
+New Mexico,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,2
+New Mexico,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,5
+New Mexico,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+New Mexico,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+New Mexico,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+New Mexico,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+New Mexico,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+New Mexico,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+New Mexico,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+New Mexico,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+New Mexico,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+New Mexico,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+New Mexico,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+New Mexico,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+New Mexico,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+New Mexico,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+New Mexico,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+New Mexico,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+New Mexico,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+New Mexico,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+New Mexico,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+New Mexico,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,2
+New Mexico,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,4
+New Mexico,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,8
+New Mexico,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,21
+New Mexico,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+New Mexico,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+New Mexico,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+New Mexico,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+New Mexico,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+New Mexico,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+New Mexico,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+New Mexico,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+New Mexico,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+New Mexico,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+New Mexico,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+New Mexico,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+New Mexico,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+New Mexico,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,2
+New Mexico,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+New Mexico,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,3
+New Mexico,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,4
+New Mexico,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,5
+New Mexico,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,7
+New Mexico,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,12
+New Mexico,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,25
+New Mexico,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,50
+New Mexico,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,121
+New Mexico,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+New Mexico,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+New Mexico,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+New Mexico,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+New Mexico,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,1
+New Mexico,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+New Mexico,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,1
+New Mexico,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,2
+New Mexico,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,2
+New Mexico,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,3
+New Mexico,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,4
+New Mexico,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,5
+New Mexico,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,6
+New Mexico,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,7
+New Mexico,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,9
+New Mexico,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,11
+New Mexico,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,14
+New Mexico,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,19
+New Mexico,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,27
+New Mexico,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,42
+New Mexico,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,85
+New Mexico,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,170
+New Mexico,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,413
+New Mexico,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+New Mexico,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+New Mexico,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+New Mexico,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+New Mexico,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+New Mexico,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,1
+New Mexico,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,1
+New Mexico,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+New Mexico,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,2
+New Mexico,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,3
+New Mexico,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,3
+New Mexico,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,4
+New Mexico,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,5
+New Mexico,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,6
+New Mexico,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,7
+New Mexico,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,9
+New Mexico,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,12
+New Mexico,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,16
+New Mexico,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,22
+New Mexico,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,35
+New Mexico,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,72
+New Mexico,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,143
+New Mexico,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,346
+New Mexico,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+New Mexico,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+New Mexico,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+New Mexico,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+New Mexico,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+New Mexico,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+New Mexico,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+New Mexico,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+New Mexico,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+New Mexico,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+New Mexico,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+New Mexico,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+New Mexico,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+New Mexico,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+New Mexico,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+New Mexico,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,2
+New Mexico,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,2
+New Mexico,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,3
+New Mexico,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,5
+New Mexico,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,7
+New Mexico,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,16
+New Mexico,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,32
+New Mexico,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,79
+New Mexico,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+New Mexico,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+New Mexico,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+New Mexico,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+New Mexico,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+New Mexico,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+New Mexico,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+New Mexico,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+New Mexico,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+New Mexico,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+New Mexico,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+New Mexico,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+New Mexico,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+New Mexico,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+New Mexico,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+New Mexico,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+New Mexico,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+New Mexico,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+New Mexico,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+New Mexico,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+New Mexico,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,2
+New Mexico,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,5
+New Mexico,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,13
+New Mexico,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+New Mexico,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+New Mexico,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+New Mexico,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+New Mexico,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+New Mexico,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+New Mexico,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+New Mexico,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+New Mexico,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+New Mexico,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+New Mexico,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+New Mexico,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+New Mexico,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+New Mexico,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+New Mexico,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+New Mexico,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+New Mexico,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+New Mexico,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+New Mexico,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+New Mexico,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+New Mexico,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+New Mexico,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+New Mexico,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,3
+New York,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+New York,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+New York,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+New York,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+New York,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+New York,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+New York,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+New York,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+New York,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+New York,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+New York,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+New York,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+New York,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+New York,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+New York,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+New York,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+New York,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+New York,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+New York,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+New York,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,0
+New York,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,1
+New York,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,3
+New York,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,8
+New York,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+New York,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+New York,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+New York,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+New York,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+New York,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+New York,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+New York,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+New York,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+New York,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+New York,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+New York,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+New York,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+New York,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+New York,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+New York,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+New York,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,1
+New York,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,1
+New York,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,2
+New York,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,3
+New York,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,6
+New York,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,13
+New York,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,33
+New York,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+New York,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+New York,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+New York,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+New York,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+New York,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+New York,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+New York,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,1
+New York,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,1
+New York,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+New York,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+New York,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,2
+New York,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,2
+New York,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,3
+New York,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,4
+New York,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,5
+New York,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,6
+New York,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,9
+New York,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,12
+New York,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,19
+New York,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,40
+New York,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,81
+New York,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,198
+New York,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+New York,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+New York,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+New York,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,1
+New York,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,1
+New York,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,2
+New York,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,3
+New York,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,3
+New York,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,4
+New York,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,5
+New York,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,7
+New York,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,8
+New York,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,10
+New York,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,12
+New York,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,15
+New York,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,18
+New York,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,23
+New York,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,31
+New York,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,43
+New York,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,67
+New York,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,139
+New York,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,277
+New York,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,679
+New York,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+New York,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+New York,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+New York,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+New York,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,1
+New York,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,1
+New York,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,2
+New York,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,3
+New York,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,4
+New York,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,4
+New York,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,5
+New York,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,7
+New York,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,8
+New York,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,10
+New York,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,12
+New York,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,15
+New York,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,20
+New York,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,26
+New York,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,36
+New York,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,57
+New York,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,117
+New York,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,233
+New York,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,569
+New York,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+New York,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+New York,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+New York,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+New York,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+New York,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+New York,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+New York,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+New York,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+New York,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,1
+New York,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,1
+New York,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,1
+New York,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+New York,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,2
+New York,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,2
+New York,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,3
+New York,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,4
+New York,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,5
+New York,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,8
+New York,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,12
+New York,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,26
+New York,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,52
+New York,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,128
+New York,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+New York,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+New York,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+New York,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+New York,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+New York,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+New York,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+New York,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+New York,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+New York,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+New York,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+New York,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+New York,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+New York,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+New York,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+New York,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+New York,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+New York,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+New York,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,1
+New York,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,2
+New York,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,4
+New York,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,8
+New York,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,21
+New York,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+New York,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+New York,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+New York,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+New York,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+New York,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+New York,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+New York,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+New York,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+New York,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+New York,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+New York,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+New York,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+New York,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+New York,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+New York,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+New York,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+New York,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+New York,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+New York,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+New York,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,1
+New York,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,2
+New York,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,5
+North Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+North Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+North Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+North Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+North Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+North Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+North Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+North Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+North Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+North Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+North Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+North Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+North Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+North Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+North Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+North Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+North Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+North Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+North Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+North Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,0
+North Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,0
+North Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,0
+North Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,1
+North Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+North Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+North Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+North Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+North Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+North Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+North Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+North Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+North Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+North Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+North Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+North Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+North Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+North Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+North Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+North Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+North Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+North Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+North Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+North Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+North Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+North Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,3
+North Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,7
+North Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+North Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+North Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+North Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+North Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+North Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+North Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+North Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+North Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+North Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+North Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+North Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+North Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+North Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+North Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+North Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+North Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+North Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,1
+North Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,2
+North Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,4
+North Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,8
+North Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,17
+North Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,43
+North Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+North Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+North Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+North Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+North Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+North Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+North Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+North Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+North Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+North Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,1
+North Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,1
+North Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,1
+North Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,2
+North Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,2
+North Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,3
+North Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,4
+North Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,5
+North Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,6
+North Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,9
+North Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,14
+North Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,30
+North Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,60
+North Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,147
+North Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+North Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+North Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+North Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+North Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+North Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+North Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+North Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+North Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+North Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+North Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,1
+North Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,1
+North Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,1
+North Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,2
+North Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,2
+North Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,3
+North Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,4
+North Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,5
+North Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,7
+North Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,12
+North Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,25
+North Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,51
+North Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,124
+North Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+North Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+North Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+North Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+North Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+North Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+North Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+North Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+North Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+North Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+North Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+North Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+North Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+North Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+North Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+North Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+North Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+North Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+North Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+North Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,2
+North Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,5
+North Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,11
+North Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,28
+North Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+North Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+North Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+North Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+North Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+North Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+North Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+North Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+North Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+North Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+North Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+North Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+North Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+North Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+North Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+North Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+North Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+North Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+North Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+North Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+North Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+North Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,1
+North Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,4
+North Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+North Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+North Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+North Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+North Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+North Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+North Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+North Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+North Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+North Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+North Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+North Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+North Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+North Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+North Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+North Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+North Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+North Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+North Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+North Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+North Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+North Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+North Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,1
+North Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+North Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+North Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+North Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+North Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+North Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+North Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+North Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+North Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+North Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+North Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+North Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+North Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+North Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+North Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+North Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+North Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+North Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+North Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+North Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,0
+North Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,0
+North Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,1
+North Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,3
+North Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+North Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+North Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+North Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+North Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+North Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+North Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+North Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+North Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+North Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+North Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+North Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+North Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+North Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+North Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+North Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+North Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+North Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+North Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+North Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+North Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,2
+North Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,5
+North Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,14
+North Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+North Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+North Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+North Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+North Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+North Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+North Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+North Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+North Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+North Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+North Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+North Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+North Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+North Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+North Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+North Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,2
+North Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,2
+North Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,3
+North Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,5
+North Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,7
+North Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,16
+North Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,33
+North Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,81
+North Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+North Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+North Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+North Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+North Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+North Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+North Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,1
+North Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,1
+North Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,1
+North Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,2
+North Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,2
+North Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,3
+North Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,4
+North Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,4
+North Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,5
+North Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,7
+North Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,9
+North Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,12
+North Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,17
+North Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,27
+North Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,56
+North Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,113
+North Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,279
+North Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+North Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+North Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+North Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+North Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+North Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+North Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+North Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+North Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,1
+North Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,1
+North Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,2
+North Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,2
+North Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,3
+North Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,4
+North Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,5
+North Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,6
+North Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,7
+North Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,10
+North Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,14
+North Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,23
+North Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,47
+North Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,95
+North Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,234
+North Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+North Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+North Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+North Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+North Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+North Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+North Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+North Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+North Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+North Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+North Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+North Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+North Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+North Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+North Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+North Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+North Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+North Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,2
+North Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,3
+North Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,5
+North Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,10
+North Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,21
+North Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,53
+North Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+North Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+North Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+North Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+North Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+North Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+North Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+North Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+North Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+North Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+North Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+North Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+North Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+North Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+North Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+North Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+North Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+North Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+North Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+North Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+North Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,1
+North Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,3
+North Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,8
+North Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+North Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+North Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+North Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+North Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+North Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+North Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+North Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+North Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+North Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+North Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+North Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+North Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+North Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+North Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+North Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+North Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+North Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+North Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+North Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+North Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+North Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+North Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,2
+Ohio,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+Ohio,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+Ohio,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+Ohio,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+Ohio,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+Ohio,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+Ohio,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+Ohio,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+Ohio,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+Ohio,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+Ohio,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+Ohio,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+Ohio,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+Ohio,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+Ohio,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+Ohio,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+Ohio,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+Ohio,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+Ohio,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+Ohio,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,0
+Ohio,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,0
+Ohio,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,2
+Ohio,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,5
+Ohio,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Ohio,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Ohio,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Ohio,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Ohio,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Ohio,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Ohio,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Ohio,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Ohio,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Ohio,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Ohio,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Ohio,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Ohio,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Ohio,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Ohio,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Ohio,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Ohio,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Ohio,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Ohio,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Ohio,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Ohio,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,4
+Ohio,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,8
+Ohio,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,20
+Ohio,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Ohio,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Ohio,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Ohio,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Ohio,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Ohio,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Ohio,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Ohio,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Ohio,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Ohio,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Ohio,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Ohio,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Ohio,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Ohio,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,2
+Ohio,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+Ohio,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,3
+Ohio,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,4
+Ohio,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,5
+Ohio,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,7
+Ohio,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,11
+Ohio,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,24
+Ohio,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,49
+Ohio,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,121
+Ohio,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Ohio,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Ohio,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Ohio,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Ohio,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,1
+Ohio,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+Ohio,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,1
+Ohio,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,2
+Ohio,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,2
+Ohio,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,3
+Ohio,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,4
+Ohio,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,5
+Ohio,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,6
+Ohio,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,7
+Ohio,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,9
+Ohio,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,11
+Ohio,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,14
+Ohio,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,18
+Ohio,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,26
+Ohio,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,41
+Ohio,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,84
+Ohio,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,168
+Ohio,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,413
+Ohio,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Ohio,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Ohio,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Ohio,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Ohio,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Ohio,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,1
+Ohio,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,1
+Ohio,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+Ohio,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,2
+Ohio,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,2
+Ohio,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,3
+Ohio,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,4
+Ohio,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,5
+Ohio,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,6
+Ohio,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,7
+Ohio,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,9
+Ohio,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,12
+Ohio,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,15
+Ohio,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,22
+Ohio,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,34
+Ohio,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,70
+Ohio,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,141
+Ohio,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,347
+Ohio,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Ohio,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Ohio,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Ohio,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Ohio,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Ohio,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Ohio,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Ohio,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Ohio,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Ohio,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Ohio,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Ohio,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Ohio,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+Ohio,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Ohio,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Ohio,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,2
+Ohio,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,2
+Ohio,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,3
+Ohio,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,4
+Ohio,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,7
+Ohio,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,16
+Ohio,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,32
+Ohio,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,78
+Ohio,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Ohio,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Ohio,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Ohio,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Ohio,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Ohio,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Ohio,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Ohio,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Ohio,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Ohio,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Ohio,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Ohio,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Ohio,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Ohio,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Ohio,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Ohio,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Ohio,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Ohio,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Ohio,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Ohio,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Ohio,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,2
+Ohio,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,5
+Ohio,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,13
+Ohio,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Ohio,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Ohio,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Ohio,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Ohio,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Ohio,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Ohio,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Ohio,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Ohio,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Ohio,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Ohio,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Ohio,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Ohio,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Ohio,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Ohio,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Ohio,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Ohio,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Ohio,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Ohio,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Ohio,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Ohio,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Ohio,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Ohio,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,3
+Oklahoma,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+Oklahoma,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+Oklahoma,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+Oklahoma,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+Oklahoma,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+Oklahoma,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+Oklahoma,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+Oklahoma,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+Oklahoma,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+Oklahoma,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+Oklahoma,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+Oklahoma,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+Oklahoma,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+Oklahoma,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+Oklahoma,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+Oklahoma,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+Oklahoma,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+Oklahoma,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+Oklahoma,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+Oklahoma,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,0
+Oklahoma,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,1
+Oklahoma,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,3
+Oklahoma,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,7
+Oklahoma,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Oklahoma,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Oklahoma,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Oklahoma,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Oklahoma,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Oklahoma,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Oklahoma,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Oklahoma,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Oklahoma,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Oklahoma,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Oklahoma,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Oklahoma,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Oklahoma,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Oklahoma,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Oklahoma,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Oklahoma,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Oklahoma,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Oklahoma,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,1
+Oklahoma,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Oklahoma,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,2
+Oklahoma,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,6
+Oklahoma,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,12
+Oklahoma,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,30
+Oklahoma,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Oklahoma,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Oklahoma,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Oklahoma,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Oklahoma,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Oklahoma,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Oklahoma,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Oklahoma,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Oklahoma,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,1
+Oklahoma,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+Oklahoma,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Oklahoma,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,2
+Oklahoma,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,2
+Oklahoma,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,3
+Oklahoma,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,3
+Oklahoma,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,4
+Oklahoma,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,6
+Oklahoma,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,8
+Oklahoma,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,11
+Oklahoma,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,17
+Oklahoma,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,36
+Oklahoma,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,72
+Oklahoma,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,178
+Oklahoma,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Oklahoma,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Oklahoma,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Oklahoma,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,1
+Oklahoma,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,1
+Oklahoma,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,2
+Oklahoma,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,2
+Oklahoma,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,3
+Oklahoma,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,4
+Oklahoma,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,5
+Oklahoma,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,6
+Oklahoma,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,7
+Oklahoma,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,9
+Oklahoma,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,11
+Oklahoma,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,13
+Oklahoma,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,16
+Oklahoma,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,21
+Oklahoma,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,28
+Oklahoma,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,39
+Oklahoma,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,61
+Oklahoma,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,124
+Oklahoma,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,249
+Oklahoma,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,608
+Oklahoma,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Oklahoma,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Oklahoma,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Oklahoma,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Oklahoma,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,1
+Oklahoma,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,1
+Oklahoma,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,2
+Oklahoma,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,2
+Oklahoma,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,3
+Oklahoma,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,4
+Oklahoma,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,5
+Oklahoma,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,6
+Oklahoma,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,7
+Oklahoma,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,9
+Oklahoma,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,11
+Oklahoma,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,14
+Oklahoma,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,18
+Oklahoma,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,23
+Oklahoma,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,33
+Oklahoma,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,51
+Oklahoma,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,105
+Oklahoma,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,209
+Oklahoma,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,510
+Oklahoma,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Oklahoma,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Oklahoma,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Oklahoma,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Oklahoma,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Oklahoma,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Oklahoma,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Oklahoma,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Oklahoma,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Oklahoma,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Oklahoma,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,1
+Oklahoma,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,1
+Oklahoma,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+Oklahoma,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,2
+Oklahoma,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,2
+Oklahoma,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,3
+Oklahoma,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,3
+Oklahoma,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,5
+Oklahoma,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,7
+Oklahoma,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,11
+Oklahoma,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,23
+Oklahoma,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,47
+Oklahoma,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,115
+Oklahoma,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Oklahoma,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Oklahoma,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Oklahoma,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Oklahoma,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Oklahoma,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Oklahoma,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Oklahoma,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Oklahoma,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Oklahoma,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Oklahoma,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Oklahoma,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Oklahoma,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Oklahoma,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Oklahoma,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Oklahoma,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Oklahoma,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Oklahoma,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Oklahoma,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,1
+Oklahoma,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Oklahoma,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,3
+Oklahoma,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,7
+Oklahoma,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,19
+Oklahoma,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Oklahoma,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Oklahoma,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Oklahoma,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Oklahoma,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Oklahoma,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Oklahoma,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Oklahoma,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Oklahoma,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Oklahoma,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Oklahoma,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Oklahoma,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Oklahoma,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Oklahoma,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Oklahoma,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Oklahoma,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Oklahoma,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Oklahoma,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Oklahoma,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Oklahoma,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Oklahoma,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Oklahoma,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Oklahoma,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,5
+Oregon,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+Oregon,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+Oregon,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+Oregon,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+Oregon,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+Oregon,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+Oregon,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+Oregon,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+Oregon,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+Oregon,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+Oregon,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+Oregon,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+Oregon,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+Oregon,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+Oregon,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+Oregon,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+Oregon,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+Oregon,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+Oregon,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+Oregon,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,0
+Oregon,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,0
+Oregon,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,0
+Oregon,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,1
+Oregon,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Oregon,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Oregon,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Oregon,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Oregon,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Oregon,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Oregon,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Oregon,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Oregon,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Oregon,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Oregon,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Oregon,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Oregon,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Oregon,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Oregon,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Oregon,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Oregon,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Oregon,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Oregon,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Oregon,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Oregon,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Oregon,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,1
+Oregon,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,4
+Oregon,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Oregon,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Oregon,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Oregon,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Oregon,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Oregon,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Oregon,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Oregon,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Oregon,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Oregon,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Oregon,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Oregon,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Oregon,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Oregon,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+Oregon,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+Oregon,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,0
+Oregon,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,0
+Oregon,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,1
+Oregon,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,1
+Oregon,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,2
+Oregon,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,4
+Oregon,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,9
+Oregon,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,24
+Oregon,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Oregon,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Oregon,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Oregon,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Oregon,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Oregon,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Oregon,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Oregon,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+Oregon,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+Oregon,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,0
+Oregon,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,0
+Oregon,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,0
+Oregon,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,1
+Oregon,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,1
+Oregon,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,1
+Oregon,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,2
+Oregon,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,2
+Oregon,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,3
+Oregon,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,5
+Oregon,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,8
+Oregon,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,16
+Oregon,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,33
+Oregon,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,82
+Oregon,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Oregon,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Oregon,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Oregon,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Oregon,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Oregon,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Oregon,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Oregon,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Oregon,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+Oregon,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+Oregon,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,0
+Oregon,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,0
+Oregon,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,0
+Oregon,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,1
+Oregon,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,1
+Oregon,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,1
+Oregon,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,2
+Oregon,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,3
+Oregon,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,4
+Oregon,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,6
+Oregon,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,14
+Oregon,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,28
+Oregon,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,69
+Oregon,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Oregon,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Oregon,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Oregon,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Oregon,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Oregon,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Oregon,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Oregon,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Oregon,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Oregon,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Oregon,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Oregon,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Oregon,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Oregon,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Oregon,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Oregon,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Oregon,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Oregon,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+Oregon,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,0
+Oregon,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,1
+Oregon,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,3
+Oregon,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,6
+Oregon,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,16
+Oregon,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Oregon,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Oregon,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Oregon,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Oregon,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Oregon,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Oregon,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Oregon,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Oregon,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Oregon,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Oregon,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Oregon,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Oregon,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Oregon,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Oregon,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Oregon,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Oregon,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Oregon,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Oregon,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Oregon,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Oregon,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Oregon,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,1
+Oregon,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,2
+Oregon,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Oregon,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Oregon,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Oregon,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Oregon,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Oregon,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Oregon,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Oregon,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Oregon,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Oregon,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Oregon,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Oregon,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Oregon,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Oregon,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Oregon,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Oregon,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Oregon,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Oregon,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Oregon,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Oregon,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Oregon,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Oregon,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Oregon,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Pennsylvania,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+Pennsylvania,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+Pennsylvania,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+Pennsylvania,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+Pennsylvania,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+Pennsylvania,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+Pennsylvania,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+Pennsylvania,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+Pennsylvania,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+Pennsylvania,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+Pennsylvania,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+Pennsylvania,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+Pennsylvania,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+Pennsylvania,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+Pennsylvania,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+Pennsylvania,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+Pennsylvania,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+Pennsylvania,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+Pennsylvania,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+Pennsylvania,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,0
+Pennsylvania,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,1
+Pennsylvania,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,2
+Pennsylvania,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,5
+Pennsylvania,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Pennsylvania,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Pennsylvania,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Pennsylvania,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Pennsylvania,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Pennsylvania,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Pennsylvania,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Pennsylvania,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Pennsylvania,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Pennsylvania,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Pennsylvania,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Pennsylvania,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Pennsylvania,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Pennsylvania,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Pennsylvania,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Pennsylvania,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Pennsylvania,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Pennsylvania,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Pennsylvania,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Pennsylvania,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,2
+Pennsylvania,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,4
+Pennsylvania,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,9
+Pennsylvania,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,23
+Pennsylvania,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Pennsylvania,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Pennsylvania,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Pennsylvania,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Pennsylvania,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Pennsylvania,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Pennsylvania,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Pennsylvania,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Pennsylvania,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Pennsylvania,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+Pennsylvania,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Pennsylvania,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Pennsylvania,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Pennsylvania,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,2
+Pennsylvania,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+Pennsylvania,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,3
+Pennsylvania,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,4
+Pennsylvania,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,6
+Pennsylvania,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,8
+Pennsylvania,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,13
+Pennsylvania,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,27
+Pennsylvania,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,55
+Pennsylvania,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,136
+Pennsylvania,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Pennsylvania,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Pennsylvania,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Pennsylvania,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Pennsylvania,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,1
+Pennsylvania,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+Pennsylvania,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,2
+Pennsylvania,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,2
+Pennsylvania,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,3
+Pennsylvania,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,3
+Pennsylvania,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,4
+Pennsylvania,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,5
+Pennsylvania,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,6
+Pennsylvania,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,8
+Pennsylvania,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,10
+Pennsylvania,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,12
+Pennsylvania,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,16
+Pennsylvania,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,21
+Pennsylvania,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,29
+Pennsylvania,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,46
+Pennsylvania,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,94
+Pennsylvania,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,189
+Pennsylvania,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,463
+Pennsylvania,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Pennsylvania,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Pennsylvania,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Pennsylvania,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Pennsylvania,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Pennsylvania,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,1
+Pennsylvania,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,1
+Pennsylvania,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,2
+Pennsylvania,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,2
+Pennsylvania,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,3
+Pennsylvania,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,3
+Pennsylvania,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,4
+Pennsylvania,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,5
+Pennsylvania,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,7
+Pennsylvania,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,8
+Pennsylvania,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,10
+Pennsylvania,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,13
+Pennsylvania,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,17
+Pennsylvania,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,25
+Pennsylvania,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,39
+Pennsylvania,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,79
+Pennsylvania,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,159
+Pennsylvania,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,389
+Pennsylvania,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Pennsylvania,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Pennsylvania,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Pennsylvania,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Pennsylvania,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Pennsylvania,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Pennsylvania,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Pennsylvania,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Pennsylvania,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Pennsylvania,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Pennsylvania,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Pennsylvania,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,1
+Pennsylvania,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+Pennsylvania,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Pennsylvania,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Pennsylvania,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,2
+Pennsylvania,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,2
+Pennsylvania,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,3
+Pennsylvania,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,5
+Pennsylvania,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,8
+Pennsylvania,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,18
+Pennsylvania,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,36
+Pennsylvania,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,88
+Pennsylvania,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Pennsylvania,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Pennsylvania,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Pennsylvania,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Pennsylvania,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Pennsylvania,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Pennsylvania,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Pennsylvania,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Pennsylvania,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Pennsylvania,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Pennsylvania,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Pennsylvania,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Pennsylvania,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Pennsylvania,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Pennsylvania,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Pennsylvania,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Pennsylvania,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Pennsylvania,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Pennsylvania,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Pennsylvania,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Pennsylvania,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,2
+Pennsylvania,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,5
+Pennsylvania,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,14
+Pennsylvania,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Pennsylvania,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Pennsylvania,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Pennsylvania,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Pennsylvania,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Pennsylvania,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Pennsylvania,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Pennsylvania,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Pennsylvania,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Pennsylvania,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Pennsylvania,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Pennsylvania,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Pennsylvania,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Pennsylvania,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Pennsylvania,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Pennsylvania,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Pennsylvania,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Pennsylvania,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Pennsylvania,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Pennsylvania,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Pennsylvania,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Pennsylvania,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Pennsylvania,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,3
+Rhode Island,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+Rhode Island,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+Rhode Island,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+Rhode Island,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+Rhode Island,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+Rhode Island,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+Rhode Island,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+Rhode Island,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+Rhode Island,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+Rhode Island,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+Rhode Island,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+Rhode Island,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+Rhode Island,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+Rhode Island,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+Rhode Island,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+Rhode Island,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+Rhode Island,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+Rhode Island,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+Rhode Island,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+Rhode Island,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,0
+Rhode Island,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,0
+Rhode Island,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,0
+Rhode Island,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,0
+Rhode Island,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Rhode Island,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Rhode Island,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Rhode Island,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Rhode Island,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Rhode Island,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Rhode Island,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Rhode Island,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Rhode Island,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Rhode Island,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Rhode Island,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Rhode Island,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Rhode Island,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Rhode Island,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Rhode Island,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Rhode Island,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Rhode Island,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Rhode Island,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Rhode Island,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Rhode Island,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Rhode Island,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Rhode Island,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+Rhode Island,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,1
+Rhode Island,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Rhode Island,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Rhode Island,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Rhode Island,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Rhode Island,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Rhode Island,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Rhode Island,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Rhode Island,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Rhode Island,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Rhode Island,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Rhode Island,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Rhode Island,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Rhode Island,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Rhode Island,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+Rhode Island,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+Rhode Island,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,0
+Rhode Island,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,0
+Rhode Island,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,0
+Rhode Island,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,0
+Rhode Island,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,0
+Rhode Island,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,1
+Rhode Island,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,3
+Rhode Island,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,8
+Rhode Island,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Rhode Island,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Rhode Island,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Rhode Island,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Rhode Island,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Rhode Island,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Rhode Island,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Rhode Island,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+Rhode Island,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+Rhode Island,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,0
+Rhode Island,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,0
+Rhode Island,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,0
+Rhode Island,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,0
+Rhode Island,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,0
+Rhode Island,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,0
+Rhode Island,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,0
+Rhode Island,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,0
+Rhode Island,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,1
+Rhode Island,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,1
+Rhode Island,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,2
+Rhode Island,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,5
+Rhode Island,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,10
+Rhode Island,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,26
+Rhode Island,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Rhode Island,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Rhode Island,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Rhode Island,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Rhode Island,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Rhode Island,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Rhode Island,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Rhode Island,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Rhode Island,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+Rhode Island,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+Rhode Island,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,0
+Rhode Island,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,0
+Rhode Island,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,0
+Rhode Island,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,0
+Rhode Island,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,0
+Rhode Island,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,0
+Rhode Island,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,0
+Rhode Island,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,0
+Rhode Island,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,1
+Rhode Island,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,2
+Rhode Island,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,4
+Rhode Island,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,9
+Rhode Island,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,22
+Rhode Island,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Rhode Island,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Rhode Island,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Rhode Island,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Rhode Island,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Rhode Island,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Rhode Island,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Rhode Island,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Rhode Island,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Rhode Island,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Rhode Island,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Rhode Island,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Rhode Island,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Rhode Island,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Rhode Island,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Rhode Island,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Rhode Island,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Rhode Island,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+Rhode Island,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,0
+Rhode Island,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,0
+Rhode Island,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,0
+Rhode Island,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,2
+Rhode Island,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,5
+Rhode Island,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Rhode Island,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Rhode Island,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Rhode Island,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Rhode Island,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Rhode Island,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Rhode Island,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Rhode Island,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Rhode Island,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Rhode Island,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Rhode Island,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Rhode Island,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Rhode Island,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Rhode Island,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Rhode Island,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Rhode Island,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Rhode Island,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Rhode Island,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Rhode Island,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Rhode Island,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Rhode Island,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Rhode Island,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Rhode Island,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+Rhode Island,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Rhode Island,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Rhode Island,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Rhode Island,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Rhode Island,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Rhode Island,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Rhode Island,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Rhode Island,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Rhode Island,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Rhode Island,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Rhode Island,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Rhode Island,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Rhode Island,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Rhode Island,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Rhode Island,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Rhode Island,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Rhode Island,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Rhode Island,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Rhode Island,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Rhode Island,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Rhode Island,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Rhode Island,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Rhode Island,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+South Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+South Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+South Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+South Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+South Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+South Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+South Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+South Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+South Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+South Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+South Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+South Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+South Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+South Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+South Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+South Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+South Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+South Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+South Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+South Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,0
+South Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,0
+South Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,0
+South Carolina,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,1
+South Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+South Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+South Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+South Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+South Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+South Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+South Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+South Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+South Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+South Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+South Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+South Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+South Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+South Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+South Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+South Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+South Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+South Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+South Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+South Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+South Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+South Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,3
+South Carolina,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,7
+South Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+South Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+South Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+South Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+South Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+South Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+South Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+South Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+South Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+South Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+South Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+South Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+South Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+South Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+South Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+South Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+South Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+South Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,1
+South Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,2
+South Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,4
+South Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,9
+South Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,18
+South Carolina,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,44
+South Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+South Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+South Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+South Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+South Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+South Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+South Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+South Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+South Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+South Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,1
+South Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,1
+South Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,1
+South Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,2
+South Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,2
+South Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,3
+South Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,4
+South Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,5
+South Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,6
+South Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,9
+South Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,15
+South Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,30
+South Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,61
+South Carolina,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,150
+South Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+South Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+South Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+South Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+South Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+South Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+South Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+South Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+South Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+South Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,1
+South Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,1
+South Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,1
+South Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,1
+South Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,2
+South Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,2
+South Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,3
+South Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,4
+South Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,5
+South Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,8
+South Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,12
+South Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,26
+South Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,52
+South Carolina,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,126
+South Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+South Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+South Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+South Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+South Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+South Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+South Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+South Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+South Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+South Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+South Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+South Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+South Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+South Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+South Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+South Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+South Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+South Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+South Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+South Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,2
+South Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,5
+South Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,11
+South Carolina,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,29
+South Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+South Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+South Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+South Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+South Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+South Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+South Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+South Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+South Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+South Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+South Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+South Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+South Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+South Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+South Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+South Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+South Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+South Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+South Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+South Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+South Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+South Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,1
+South Carolina,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,4
+South Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+South Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+South Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+South Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+South Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+South Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+South Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+South Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+South Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+South Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+South Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+South Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+South Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+South Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+South Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+South Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+South Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+South Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+South Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+South Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+South Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+South Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+South Carolina,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,1
+South Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+South Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+South Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+South Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+South Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+South Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+South Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+South Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+South Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+South Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+South Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+South Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+South Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+South Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+South Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+South Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+South Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+South Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+South Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+South Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,0
+South Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,1
+South Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,2
+South Dakota,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,5
+South Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+South Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+South Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+South Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+South Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+South Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+South Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+South Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+South Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+South Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+South Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+South Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+South Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+South Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+South Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+South Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+South Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+South Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+South Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+South Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,2
+South Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,4
+South Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,9
+South Dakota,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,22
+South Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+South Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+South Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+South Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+South Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+South Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+South Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+South Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+South Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+South Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+South Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+South Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+South Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+South Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,2
+South Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+South Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,3
+South Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,4
+South Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,5
+South Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,8
+South Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,12
+South Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,26
+South Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,53
+South Dakota,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,131
+South Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+South Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+South Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+South Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+South Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,1
+South Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+South Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,1
+South Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,2
+South Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,3
+South Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,3
+South Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,4
+South Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,5
+South Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,6
+South Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,7
+South Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,9
+South Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,12
+South Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,15
+South Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,20
+South Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,28
+South Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,44
+South Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,91
+South Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,183
+South Dakota,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,449
+South Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+South Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+South Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+South Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+South Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+South Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,1
+South Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,1
+South Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,2
+South Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,2
+South Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,3
+South Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,3
+South Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,4
+South Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,5
+South Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,6
+South Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,8
+South Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,10
+South Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,13
+South Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,17
+South Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,23
+South Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,37
+South Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,76
+South Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,153
+South Dakota,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,378
+South Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+South Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+South Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+South Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+South Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+South Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+South Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+South Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+South Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+South Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+South Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+South Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+South Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+South Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+South Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+South Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,2
+South Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,2
+South Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,3
+South Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,5
+South Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,8
+South Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,17
+South Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,34
+South Dakota,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,85
+South Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+South Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+South Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+South Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+South Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+South Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+South Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+South Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+South Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+South Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+South Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+South Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+South Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+South Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+South Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+South Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+South Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+South Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+South Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+South Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+South Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,2
+South Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,5
+South Dakota,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,14
+South Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+South Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+South Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+South Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+South Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+South Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+South Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+South Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+South Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+South Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+South Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+South Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+South Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+South Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+South Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+South Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+South Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+South Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+South Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+South Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+South Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+South Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+South Dakota,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,3
+Tennessee,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+Tennessee,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+Tennessee,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+Tennessee,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+Tennessee,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+Tennessee,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+Tennessee,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+Tennessee,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+Tennessee,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+Tennessee,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+Tennessee,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+Tennessee,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+Tennessee,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+Tennessee,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+Tennessee,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+Tennessee,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+Tennessee,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+Tennessee,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+Tennessee,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+Tennessee,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,0
+Tennessee,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,0
+Tennessee,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,1
+Tennessee,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,4
+Tennessee,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Tennessee,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Tennessee,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Tennessee,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Tennessee,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Tennessee,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Tennessee,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Tennessee,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Tennessee,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Tennessee,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Tennessee,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Tennessee,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Tennessee,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Tennessee,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Tennessee,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Tennessee,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Tennessee,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Tennessee,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Tennessee,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Tennessee,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Tennessee,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,3
+Tennessee,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,6
+Tennessee,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,16
+Tennessee,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Tennessee,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Tennessee,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Tennessee,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Tennessee,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Tennessee,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Tennessee,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Tennessee,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Tennessee,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Tennessee,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Tennessee,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Tennessee,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Tennessee,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Tennessee,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+Tennessee,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+Tennessee,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,2
+Tennessee,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,3
+Tennessee,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,4
+Tennessee,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,6
+Tennessee,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,9
+Tennessee,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,19
+Tennessee,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,38
+Tennessee,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,94
+Tennessee,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Tennessee,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Tennessee,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Tennessee,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Tennessee,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Tennessee,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+Tennessee,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,1
+Tennessee,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,1
+Tennessee,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,2
+Tennessee,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,2
+Tennessee,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,3
+Tennessee,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,4
+Tennessee,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,4
+Tennessee,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,5
+Tennessee,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,7
+Tennessee,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,8
+Tennessee,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,11
+Tennessee,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,14
+Tennessee,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,20
+Tennessee,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,32
+Tennessee,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,66
+Tennessee,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,131
+Tennessee,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,320
+Tennessee,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Tennessee,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Tennessee,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Tennessee,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Tennessee,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Tennessee,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Tennessee,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,1
+Tennessee,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+Tennessee,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,1
+Tennessee,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,2
+Tennessee,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,2
+Tennessee,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,3
+Tennessee,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,4
+Tennessee,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,4
+Tennessee,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,6
+Tennessee,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,7
+Tennessee,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,9
+Tennessee,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,12
+Tennessee,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,17
+Tennessee,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,27
+Tennessee,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,55
+Tennessee,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,110
+Tennessee,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,268
+Tennessee,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Tennessee,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Tennessee,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Tennessee,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Tennessee,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Tennessee,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Tennessee,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Tennessee,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Tennessee,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Tennessee,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Tennessee,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Tennessee,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Tennessee,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Tennessee,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Tennessee,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Tennessee,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Tennessee,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,2
+Tennessee,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,2
+Tennessee,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,3
+Tennessee,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,6
+Tennessee,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,12
+Tennessee,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,25
+Tennessee,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,61
+Tennessee,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Tennessee,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Tennessee,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Tennessee,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Tennessee,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Tennessee,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Tennessee,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Tennessee,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Tennessee,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Tennessee,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Tennessee,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Tennessee,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Tennessee,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Tennessee,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Tennessee,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Tennessee,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Tennessee,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Tennessee,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Tennessee,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Tennessee,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Tennessee,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,2
+Tennessee,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,4
+Tennessee,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,10
+Tennessee,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Tennessee,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Tennessee,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Tennessee,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Tennessee,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Tennessee,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Tennessee,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Tennessee,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Tennessee,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Tennessee,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Tennessee,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Tennessee,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Tennessee,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Tennessee,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Tennessee,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Tennessee,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Tennessee,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Tennessee,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Tennessee,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Tennessee,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Tennessee,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Tennessee,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Tennessee,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,2
+Texas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+Texas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+Texas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+Texas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+Texas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+Texas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+Texas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+Texas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+Texas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+Texas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+Texas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+Texas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+Texas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+Texas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+Texas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,1
+Texas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,1
+Texas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,1
+Texas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,2
+Texas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,3
+Texas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,5
+Texas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,10
+Texas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,21
+Texas,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,52
+Texas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Texas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Texas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Texas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Texas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Texas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Texas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Texas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,1
+Texas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,1
+Texas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,1
+Texas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,2
+Texas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,2
+Texas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,3
+Texas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,3
+Texas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,4
+Texas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,5
+Texas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,7
+Texas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,9
+Texas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,13
+Texas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,20
+Texas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,42
+Texas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,84
+Texas,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,205
+Texas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Texas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Texas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,1
+Texas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,2
+Texas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,3
+Texas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,4
+Texas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,5
+Texas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,7
+Texas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,8
+Texas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,10
+Texas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,12
+Texas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,15
+Texas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,18
+Texas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,22
+Texas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,27
+Texas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,34
+Texas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,43
+Texas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,56
+Texas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,79
+Texas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,123
+Texas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,252
+Texas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,503
+Texas,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,1230
+Texas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,1
+Texas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,2
+Texas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,4
+Texas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,7
+Texas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,11
+Texas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,15
+Texas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,20
+Texas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,25
+Texas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,30
+Texas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,37
+Texas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,44
+Texas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,53
+Texas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,64
+Texas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,78
+Texas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,95
+Texas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,118
+Texas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,149
+Texas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,196
+Texas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,273
+Texas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,425
+Texas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,869
+Texas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,1731
+Texas,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,4222
+Texas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Texas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,1
+Texas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,3
+Texas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,6
+Texas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,9
+Texas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,13
+Texas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,17
+Texas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,21
+Texas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,25
+Texas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,31
+Texas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,37
+Texas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,45
+Texas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,54
+Texas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,66
+Texas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,80
+Texas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,99
+Texas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,126
+Texas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,165
+Texas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,230
+Texas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,358
+Texas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,731
+Texas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,1453
+Texas,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,3540
+Texas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Texas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Texas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Texas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,1
+Texas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,2
+Texas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,2
+Texas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,3
+Texas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,4
+Texas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,5
+Texas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,6
+Texas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,8
+Texas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,10
+Texas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,12
+Texas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,14
+Texas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,17
+Texas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,22
+Texas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,28
+Texas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,37
+Texas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,51
+Texas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,80
+Texas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,163
+Texas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,325
+Texas,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,793
+Texas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Texas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Texas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Texas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Texas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Texas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Texas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Texas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Texas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Texas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,1
+Texas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,1
+Texas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,1
+Texas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,1
+Texas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,2
+Texas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,2
+Texas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,3
+Texas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,4
+Texas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,5
+Texas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,8
+Texas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,12
+Texas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,26
+Texas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,52
+Texas,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,128
+Texas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Texas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Texas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Texas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Texas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Texas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Texas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Texas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Texas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Texas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Texas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Texas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Texas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Texas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Texas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Texas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Texas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,1
+Texas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,1
+Texas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,2
+Texas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,3
+Texas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,6
+Texas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,13
+Texas,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,33
+Utah,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+Utah,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+Utah,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+Utah,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+Utah,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+Utah,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+Utah,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+Utah,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+Utah,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+Utah,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+Utah,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+Utah,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+Utah,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+Utah,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+Utah,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+Utah,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+Utah,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+Utah,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+Utah,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+Utah,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,0
+Utah,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,0
+Utah,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,0
+Utah,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,2
+Utah,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Utah,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Utah,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Utah,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Utah,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Utah,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Utah,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Utah,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Utah,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Utah,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Utah,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Utah,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Utah,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Utah,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Utah,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Utah,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Utah,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Utah,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Utah,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Utah,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Utah,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Utah,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,3
+Utah,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,8
+Utah,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Utah,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Utah,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Utah,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Utah,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Utah,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Utah,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Utah,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Utah,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Utah,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Utah,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Utah,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Utah,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Utah,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+Utah,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+Utah,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+Utah,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+Utah,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,2
+Utah,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,3
+Utah,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,5
+Utah,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,10
+Utah,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,21
+Utah,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,52
+Utah,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Utah,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Utah,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Utah,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Utah,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Utah,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Utah,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Utah,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+Utah,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,1
+Utah,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,1
+Utah,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,1
+Utah,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,2
+Utah,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,2
+Utah,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,3
+Utah,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,3
+Utah,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,4
+Utah,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,5
+Utah,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,7
+Utah,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,11
+Utah,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,17
+Utah,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,35
+Utah,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,71
+Utah,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,177
+Utah,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Utah,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Utah,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Utah,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Utah,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Utah,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Utah,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Utah,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Utah,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+Utah,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,1
+Utah,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,1
+Utah,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,1
+Utah,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,2
+Utah,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,2
+Utah,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,3
+Utah,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,3
+Utah,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,5
+Utah,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,6
+Utah,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,9
+Utah,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,14
+Utah,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,30
+Utah,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,60
+Utah,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,149
+Utah,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Utah,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Utah,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Utah,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Utah,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Utah,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Utah,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Utah,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Utah,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Utah,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Utah,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Utah,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Utah,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Utah,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Utah,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Utah,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Utah,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Utah,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Utah,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,2
+Utah,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,3
+Utah,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,6
+Utah,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,13
+Utah,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,34
+Utah,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Utah,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Utah,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Utah,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Utah,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Utah,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Utah,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Utah,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Utah,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Utah,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Utah,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Utah,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Utah,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Utah,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Utah,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Utah,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Utah,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Utah,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Utah,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Utah,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Utah,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,1
+Utah,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,2
+Utah,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,5
+Utah,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Utah,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Utah,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Utah,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Utah,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Utah,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Utah,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Utah,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Utah,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Utah,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Utah,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Utah,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Utah,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Utah,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Utah,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Utah,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Utah,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Utah,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Utah,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Utah,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Utah,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Utah,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Utah,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,1
+Vermont,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+Vermont,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+Vermont,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+Vermont,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+Vermont,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+Vermont,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+Vermont,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+Vermont,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+Vermont,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+Vermont,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+Vermont,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+Vermont,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+Vermont,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+Vermont,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+Vermont,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+Vermont,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+Vermont,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+Vermont,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+Vermont,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+Vermont,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,0
+Vermont,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,0
+Vermont,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,0
+Vermont,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,0
+Vermont,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Vermont,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Vermont,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Vermont,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Vermont,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Vermont,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Vermont,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Vermont,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Vermont,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Vermont,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Vermont,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Vermont,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Vermont,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Vermont,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Vermont,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Vermont,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Vermont,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Vermont,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Vermont,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Vermont,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Vermont,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Vermont,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+Vermont,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,1
+Vermont,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Vermont,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Vermont,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Vermont,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Vermont,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Vermont,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Vermont,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Vermont,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Vermont,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Vermont,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Vermont,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Vermont,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Vermont,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Vermont,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+Vermont,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+Vermont,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,0
+Vermont,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,0
+Vermont,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,0
+Vermont,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,0
+Vermont,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,0
+Vermont,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,1
+Vermont,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,3
+Vermont,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,9
+Vermont,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Vermont,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Vermont,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Vermont,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Vermont,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Vermont,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Vermont,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Vermont,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+Vermont,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+Vermont,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,0
+Vermont,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,0
+Vermont,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,0
+Vermont,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,0
+Vermont,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,0
+Vermont,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,0
+Vermont,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,0
+Vermont,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,1
+Vermont,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,1
+Vermont,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,2
+Vermont,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,3
+Vermont,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,6
+Vermont,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,13
+Vermont,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,32
+Vermont,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Vermont,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Vermont,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Vermont,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Vermont,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Vermont,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Vermont,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Vermont,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Vermont,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+Vermont,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+Vermont,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,0
+Vermont,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,0
+Vermont,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,0
+Vermont,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,0
+Vermont,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,0
+Vermont,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,0
+Vermont,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,0
+Vermont,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,1
+Vermont,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,1
+Vermont,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,2
+Vermont,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,5
+Vermont,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,11
+Vermont,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,27
+Vermont,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Vermont,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Vermont,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Vermont,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Vermont,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Vermont,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Vermont,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Vermont,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Vermont,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Vermont,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Vermont,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Vermont,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Vermont,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Vermont,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Vermont,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Vermont,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Vermont,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Vermont,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+Vermont,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,0
+Vermont,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,0
+Vermont,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,1
+Vermont,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,2
+Vermont,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,6
+Vermont,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Vermont,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Vermont,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Vermont,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Vermont,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Vermont,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Vermont,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Vermont,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Vermont,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Vermont,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Vermont,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Vermont,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Vermont,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Vermont,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Vermont,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Vermont,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Vermont,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Vermont,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Vermont,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Vermont,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Vermont,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Vermont,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Vermont,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,1
+Vermont,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Vermont,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Vermont,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Vermont,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Vermont,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Vermont,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Vermont,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Vermont,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Vermont,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Vermont,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Vermont,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Vermont,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Vermont,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Vermont,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Vermont,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Vermont,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Vermont,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Vermont,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Vermont,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Vermont,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Vermont,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Vermont,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Vermont,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,0
+Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,0
+Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,0
+Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,2
+Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,3
+Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,9
+Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,2
+Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,3
+Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,5
+Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,11
+Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,22
+Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,55
+Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,1
+Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,1
+Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,1
+Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,2
+Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,2
+Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,3
+Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,4
+Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,5
+Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,6
+Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,8
+Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,11
+Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,18
+Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,38
+Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,76
+Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,187
+Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,1
+Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,1
+Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,1
+Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,1
+Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,2
+Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,2
+Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,3
+Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,4
+Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,5
+Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,7
+Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,10
+Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,15
+Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,32
+Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,64
+Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,157
+Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,2
+Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,3
+Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,7
+Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,14
+Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,36
+Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,1
+Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,2
+Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,5
+Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,1
+Washington,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+Washington,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+Washington,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+Washington,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+Washington,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+Washington,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+Washington,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+Washington,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+Washington,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+Washington,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+Washington,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+Washington,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+Washington,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+Washington,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+Washington,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+Washington,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+Washington,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+Washington,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+Washington,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+Washington,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,0
+Washington,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,0
+Washington,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,0
+Washington,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,1
+Washington,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Washington,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Washington,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Washington,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Washington,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Washington,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Washington,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Washington,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Washington,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Washington,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Washington,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Washington,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Washington,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Washington,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Washington,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Washington,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Washington,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Washington,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Washington,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Washington,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Washington,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Washington,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,2
+Washington,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,6
+Washington,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Washington,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Washington,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Washington,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Washington,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Washington,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Washington,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Washington,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Washington,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Washington,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Washington,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Washington,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Washington,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Washington,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+Washington,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+Washington,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,0
+Washington,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+Washington,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,1
+Washington,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,2
+Washington,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,3
+Washington,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,8
+Washington,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,16
+Washington,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,40
+Washington,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Washington,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Washington,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Washington,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Washington,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Washington,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Washington,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Washington,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+Washington,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+Washington,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,1
+Washington,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,1
+Washington,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,1
+Washington,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,1
+Washington,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,2
+Washington,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,2
+Washington,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,3
+Washington,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,4
+Washington,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,6
+Washington,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,8
+Washington,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,13
+Washington,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,27
+Washington,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,55
+Washington,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,135
+Washington,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Washington,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Washington,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Washington,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Washington,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Washington,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Washington,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Washington,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Washington,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+Washington,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+Washington,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,1
+Washington,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,1
+Washington,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,1
+Washington,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,1
+Washington,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,2
+Washington,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,3
+Washington,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,3
+Washington,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,5
+Washington,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,7
+Washington,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,11
+Washington,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,23
+Washington,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,46
+Washington,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,113
+Washington,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Washington,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Washington,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Washington,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Washington,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Washington,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Washington,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Washington,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Washington,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Washington,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Washington,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Washington,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Washington,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Washington,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Washington,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Washington,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Washington,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Washington,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Washington,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+Washington,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,2
+Washington,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,5
+Washington,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,10
+Washington,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,26
+Washington,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Washington,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Washington,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Washington,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Washington,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Washington,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Washington,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Washington,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Washington,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Washington,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Washington,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Washington,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Washington,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Washington,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Washington,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Washington,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Washington,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Washington,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Washington,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Washington,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Washington,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Washington,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,1
+Washington,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,4
+Washington,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Washington,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Washington,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Washington,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Washington,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Washington,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Washington,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Washington,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Washington,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Washington,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Washington,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Washington,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Washington,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Washington,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Washington,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Washington,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Washington,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Washington,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Washington,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Washington,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Washington,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Washington,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Washington,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,1
+West Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+West Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+West Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+West Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+West Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+West Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+West Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+West Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+West Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+West Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+West Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+West Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+West Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+West Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+West Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+West Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+West Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+West Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+West Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+West Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,0
+West Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,0
+West Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,0
+West Virginia,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,0
+West Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+West Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+West Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+West Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+West Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+West Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+West Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+West Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+West Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+West Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+West Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+West Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+West Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+West Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+West Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+West Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+West Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+West Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+West Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+West Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+West Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+West Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+West Virginia,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,1
+West Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+West Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+West Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+West Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+West Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+West Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+West Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+West Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+West Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+West Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+West Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+West Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+West Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+West Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+West Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+West Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,0
+West Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,0
+West Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,0
+West Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,0
+West Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,0
+West Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,1
+West Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,3
+West Virginia,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,8
+West Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+West Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+West Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+West Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+West Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+West Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+West Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+West Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+West Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+West Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,0
+West Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,0
+West Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,0
+West Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,0
+West Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,0
+West Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,0
+West Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,0
+West Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,0
+West Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,1
+West Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,1
+West Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,2
+West Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,5
+West Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,11
+West Virginia,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,27
+West Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+West Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+West Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+West Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+West Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+West Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+West Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+West Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+West Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+West Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+West Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,0
+West Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,0
+West Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,0
+West Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,0
+West Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,0
+West Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,0
+West Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,0
+West Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,0
+West Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,1
+West Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,2
+West Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,4
+West Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,9
+West Virginia,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,22
+West Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+West Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+West Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+West Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+West Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+West Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+West Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+West Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+West Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+West Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+West Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+West Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+West Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+West Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+West Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+West Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+West Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+West Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+West Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,0
+West Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,0
+West Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,1
+West Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,2
+West Virginia,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,5
+West Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+West Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+West Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+West Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+West Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+West Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+West Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+West Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+West Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+West Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+West Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+West Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+West Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+West Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+West Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+West Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+West Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+West Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+West Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+West Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+West Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+West Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+West Virginia,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+West Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+West Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+West Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+West Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+West Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+West Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+West Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+West Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+West Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+West Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+West Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+West Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+West Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+West Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+West Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+West Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+West Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+West Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+West Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+West Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+West Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+West Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+West Virginia,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Wisconsin,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+Wisconsin,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+Wisconsin,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+Wisconsin,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+Wisconsin,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+Wisconsin,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+Wisconsin,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+Wisconsin,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+Wisconsin,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+Wisconsin,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+Wisconsin,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+Wisconsin,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+Wisconsin,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+Wisconsin,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+Wisconsin,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+Wisconsin,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+Wisconsin,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+Wisconsin,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+Wisconsin,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+Wisconsin,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,0
+Wisconsin,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,0
+Wisconsin,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,1
+Wisconsin,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,2
+Wisconsin,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Wisconsin,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Wisconsin,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Wisconsin,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Wisconsin,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Wisconsin,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Wisconsin,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Wisconsin,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Wisconsin,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Wisconsin,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Wisconsin,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Wisconsin,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Wisconsin,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Wisconsin,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Wisconsin,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Wisconsin,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Wisconsin,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Wisconsin,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Wisconsin,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Wisconsin,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Wisconsin,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,2
+Wisconsin,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,4
+Wisconsin,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,11
+Wisconsin,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Wisconsin,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Wisconsin,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Wisconsin,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Wisconsin,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Wisconsin,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Wisconsin,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Wisconsin,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Wisconsin,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Wisconsin,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Wisconsin,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Wisconsin,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Wisconsin,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Wisconsin,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+Wisconsin,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+Wisconsin,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+Wisconsin,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,2
+Wisconsin,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,2
+Wisconsin,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,4
+Wisconsin,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,6
+Wisconsin,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,13
+Wisconsin,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,27
+Wisconsin,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,67
+Wisconsin,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Wisconsin,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Wisconsin,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Wisconsin,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Wisconsin,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Wisconsin,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Wisconsin,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Wisconsin,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,1
+Wisconsin,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,1
+Wisconsin,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,1
+Wisconsin,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,2
+Wisconsin,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,2
+Wisconsin,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,3
+Wisconsin,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,4
+Wisconsin,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,5
+Wisconsin,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,6
+Wisconsin,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,7
+Wisconsin,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,10
+Wisconsin,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,14
+Wisconsin,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,22
+Wisconsin,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,47
+Wisconsin,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,93
+Wisconsin,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,230
+Wisconsin,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Wisconsin,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Wisconsin,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Wisconsin,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Wisconsin,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Wisconsin,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Wisconsin,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Wisconsin,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+Wisconsin,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,1
+Wisconsin,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,1
+Wisconsin,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,1
+Wisconsin,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,2
+Wisconsin,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,2
+Wisconsin,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,3
+Wisconsin,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,4
+Wisconsin,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,5
+Wisconsin,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,6
+Wisconsin,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,8
+Wisconsin,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,12
+Wisconsin,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,19
+Wisconsin,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,39
+Wisconsin,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,79
+Wisconsin,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,193
+Wisconsin,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Wisconsin,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Wisconsin,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Wisconsin,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Wisconsin,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Wisconsin,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Wisconsin,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Wisconsin,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Wisconsin,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Wisconsin,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Wisconsin,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Wisconsin,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Wisconsin,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Wisconsin,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Wisconsin,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Wisconsin,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Wisconsin,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Wisconsin,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Wisconsin,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,2
+Wisconsin,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,4
+Wisconsin,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,8
+Wisconsin,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,18
+Wisconsin,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,44
+Wisconsin,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Wisconsin,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Wisconsin,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Wisconsin,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Wisconsin,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Wisconsin,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Wisconsin,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Wisconsin,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Wisconsin,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Wisconsin,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Wisconsin,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Wisconsin,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Wisconsin,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Wisconsin,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Wisconsin,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Wisconsin,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Wisconsin,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Wisconsin,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Wisconsin,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Wisconsin,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Wisconsin,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,1
+Wisconsin,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,2
+Wisconsin,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,7
+Wisconsin,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Wisconsin,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Wisconsin,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Wisconsin,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Wisconsin,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Wisconsin,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Wisconsin,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Wisconsin,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Wisconsin,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Wisconsin,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Wisconsin,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Wisconsin,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Wisconsin,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Wisconsin,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Wisconsin,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Wisconsin,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Wisconsin,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Wisconsin,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Wisconsin,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Wisconsin,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Wisconsin,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Wisconsin,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Wisconsin,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,1
+Wyoming,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.01,0
+Wyoming,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.025,0
+Wyoming,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.05,0
+Wyoming,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.1,0
+Wyoming,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.15,0
+Wyoming,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.2,0
+Wyoming,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.25,0
+Wyoming,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.3,0
+Wyoming,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.35,0
+Wyoming,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.4,0
+Wyoming,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.45,0
+Wyoming,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.5,0
+Wyoming,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.55,0
+Wyoming,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.6,0
+Wyoming,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.65,0
+Wyoming,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.7,0
+Wyoming,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.75,0
+Wyoming,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.8,0
+Wyoming,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.85,0
+Wyoming,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.9,0
+Wyoming,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.95,0
+Wyoming,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.975,0
+Wyoming,2023-04-30,2023-05-31,May WNV neuroinvasive disease cases,quantile,0.99,1
+Wyoming,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Wyoming,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Wyoming,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Wyoming,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Wyoming,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Wyoming,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Wyoming,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Wyoming,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Wyoming,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Wyoming,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Wyoming,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Wyoming,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Wyoming,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Wyoming,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Wyoming,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Wyoming,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Wyoming,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Wyoming,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Wyoming,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Wyoming,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Wyoming,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Wyoming,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,2
+Wyoming,2023-04-30,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,6
+Wyoming,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Wyoming,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Wyoming,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Wyoming,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Wyoming,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Wyoming,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Wyoming,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Wyoming,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Wyoming,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Wyoming,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Wyoming,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Wyoming,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Wyoming,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Wyoming,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+Wyoming,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+Wyoming,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,0
+Wyoming,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+Wyoming,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,1
+Wyoming,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,2
+Wyoming,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,3
+Wyoming,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,7
+Wyoming,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,14
+Wyoming,2023-04-30,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,36
+Wyoming,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Wyoming,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Wyoming,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Wyoming,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Wyoming,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Wyoming,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Wyoming,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Wyoming,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+Wyoming,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+Wyoming,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,0
+Wyoming,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,1
+Wyoming,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,1
+Wyoming,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,1
+Wyoming,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,2
+Wyoming,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,2
+Wyoming,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,3
+Wyoming,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,4
+Wyoming,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,5
+Wyoming,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,7
+Wyoming,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,12
+Wyoming,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,25
+Wyoming,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,50
+Wyoming,2023-04-30,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,122
+Wyoming,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Wyoming,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Wyoming,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Wyoming,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Wyoming,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Wyoming,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Wyoming,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Wyoming,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Wyoming,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+Wyoming,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+Wyoming,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,0
+Wyoming,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,1
+Wyoming,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,1
+Wyoming,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,1
+Wyoming,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,2
+Wyoming,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,2
+Wyoming,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,3
+Wyoming,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,4
+Wyoming,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,6
+Wyoming,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,10
+Wyoming,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,21
+Wyoming,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,42
+Wyoming,2023-04-30,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,103
+Wyoming,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Wyoming,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Wyoming,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Wyoming,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Wyoming,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Wyoming,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Wyoming,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Wyoming,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Wyoming,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Wyoming,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Wyoming,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Wyoming,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Wyoming,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Wyoming,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Wyoming,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Wyoming,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Wyoming,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Wyoming,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+Wyoming,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+Wyoming,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,2
+Wyoming,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,4
+Wyoming,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,9
+Wyoming,2023-04-30,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,23
+Wyoming,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Wyoming,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Wyoming,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Wyoming,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Wyoming,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Wyoming,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Wyoming,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Wyoming,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Wyoming,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Wyoming,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Wyoming,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Wyoming,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Wyoming,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Wyoming,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Wyoming,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Wyoming,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Wyoming,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Wyoming,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Wyoming,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Wyoming,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Wyoming,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Wyoming,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,1
+Wyoming,2023-04-30,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,3
+Wyoming,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Wyoming,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Wyoming,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Wyoming,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Wyoming,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Wyoming,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Wyoming,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Wyoming,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Wyoming,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Wyoming,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Wyoming,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Wyoming,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Wyoming,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Wyoming,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Wyoming,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Wyoming,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Wyoming,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Wyoming,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Wyoming,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Wyoming,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Wyoming,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Wyoming,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Wyoming,2023-04-30,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0

--- a/data-forecasts/sentinel-gamlss/2023-05-31-sentinel-gamlss.csv
+++ b/data-forecasts/sentinel-gamlss/2023-05-31-sentinel-gamlss.csv
@@ -1,0 +1,7890 @@
+location,forecast_date,target_end_date,target,type,quantile,value
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,3
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,7
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,17
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,2
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,3
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,4
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,6
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,10
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,20
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,41
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,102
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,1
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,1
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,2
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,2
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,3
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,4
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,5
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,6
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,7
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,9
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,12
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,16
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,22
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,34
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,71
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,142
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,346
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,1
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,2
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,2
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,2
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,3
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,4
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,5
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,6
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,8
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,10
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,13
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,18
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,29
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,59
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,119
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,291
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,2
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,2
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,4
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,6
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,13
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,27
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,66
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,2
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,4
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,11
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,2
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,1
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,1
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,1
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,1
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,2
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,2
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,3
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,4
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,6
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,8
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,13
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,27
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,55
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,137
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,1
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,2
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,2
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,3
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,4
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,5
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,6
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,8
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,10
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,12
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,14
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,18
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,22
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,28
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,37
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,52
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,81
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,166
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,333
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,817
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,1
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,2
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,5
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,7
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,10
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,13
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,16
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,20
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,24
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,29
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,35
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,42
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,51
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,62
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,77
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,98
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,129
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,179
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,280
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,573
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,1145
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,2806
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,1
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,2
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,4
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,6
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,8
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,11
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,13
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,16
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,20
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,24
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,29
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,35
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,43
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,52
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,65
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,82
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,108
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,151
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,235
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,482
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,962
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,2354
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,1
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,1
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,2
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,2
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,3
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,4
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,5
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,6
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,7
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,9
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,11
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,14
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,18
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,24
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,33
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,52
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,108
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,215
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,528
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,1
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,1
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,1
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,2
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,2
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,3
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,5
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,8
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,17
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,34
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,85
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,1
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,2
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,4
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,9
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,22
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,3
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,8
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,19
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,2
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,3
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,3
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,5
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,7
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,11
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,23
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,47
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,115
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,1
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,2
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,2
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,3
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,4
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,4
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,5
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,7
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,8
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,10
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,13
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,18
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,25
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,39
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,80
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,160
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,391
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,1
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,1
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,2
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,2
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,3
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,4
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,4
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,6
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,7
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,9
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,11
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,15
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,21
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,33
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,67
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,135
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,328
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,2
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,3
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,4
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,7
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,15
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,30
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,74
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,2
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,5
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,12
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,3
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,1
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,1
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,1
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,2
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,2
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,3
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,4
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,4
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,6
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,7
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,9
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,12
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,17
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,27
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,56
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,112
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,274
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,1
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,2
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,4
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,6
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,7
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,9
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,11
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,14
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,17
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,20
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,25
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,30
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,37
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,45
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,58
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,76
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,106
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,165
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,337
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,672
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,1641
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,1
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,3
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,5
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,10
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,15
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,21
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,27
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,33
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,41
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,50
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,60
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,72
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,86
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,105
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,128
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,158
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,200
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,263
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,366
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,569
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,1162
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,2312
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,5634
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,1
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,2
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,4
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,8
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,13
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,17
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,22
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,28
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,34
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,42
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,50
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,60
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,73
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,88
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,107
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,133
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,169
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,222
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,308
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,479
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,977
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,1941
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,4721
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,1
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,2
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,3
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,5
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,6
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,7
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,9
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,11
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,13
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,16
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,19
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,24
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,29
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,37
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,49
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,69
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,107
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,218
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,435
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,1058
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,1
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,1
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,1
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,2
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,2
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,3
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,3
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,4
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,5
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,7
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,10
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,17
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,35
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,70
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,171
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,1
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,1
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,1
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,2
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,4
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,9
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,18
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,44
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,1
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,1
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,1
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,2
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,4
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,9
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,18
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,46
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,1
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,1
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,1
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,2
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,2
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,3
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,3
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,4
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,5
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,7
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,9
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,12
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,17
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,27
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,55
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,112
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,275
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,1
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,2
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,3
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,4
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,5
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,6
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,8
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,9
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,11
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,14
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,17
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,20
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,25
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,32
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,43
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,60
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,93
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,192
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,384
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,945
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,1
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,2
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,2
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,3
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,4
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,5
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,6
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,8
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,9
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,11
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,14
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,17
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,21
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,27
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,36
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,50
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,78
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,161
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,323
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,793
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,1
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,1
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,1
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,2
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,2
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,3
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,3
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,4
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,6
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,8
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,11
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,17
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,36
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,72
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,178
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,1
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,1
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,2
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,5
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,11
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,29
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,1
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,3
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,7
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,3
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,7
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,1
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,2
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,4
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,8
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,17
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,43
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,1
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,1
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,1
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,2
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,2
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,3
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,3
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,5
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,6
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,9
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,14
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,30
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,60
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,147
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,1
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,1
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,1
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,2
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,2
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,3
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,4
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,5
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,7
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,12
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,25
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,50
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,124
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,2
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,5
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,11
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,28
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,1
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,4
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,1
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,1
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,2
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,4
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,10
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,0
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,0
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,0
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,0
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,0
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,0
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,0
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,1
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,1
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,2
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,3
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,7
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,14
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,34
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,0
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,0
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,0
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,0
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,0
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,0
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,0
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,1
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,1
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,2
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,5
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,11
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,29
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,1
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,2
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,6
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,1
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,1
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,4
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,1
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,1
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,2
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,4
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,9
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,24
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,0
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,0
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,0
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,1
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,1
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,1
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,2
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,2
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,3
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,5
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,8
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,16
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,33
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,82
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,1
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,1
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,1
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,2
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,3
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,4
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,6
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,14
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,28
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,69
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,1
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,3
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,6
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,15
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,2
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,1
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,2
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,5
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,10
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,26
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,2
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,2
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,3
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,4
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,5
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,6
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,9
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,15
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,31
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,62
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,153
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,1
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,2
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,2
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,3
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,4
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,5
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,6
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,7
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,9
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,11
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,14
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,18
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,24
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,33
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,52
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,107
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,214
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,522
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,1
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,1
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,1
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,2
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,3
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,3
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,4
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,5
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,6
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,8
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,9
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,12
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,15
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,20
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,28
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,44
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,90
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,179
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,438
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,1
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,2
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,2
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,3
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,4
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,6
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,9
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,20
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,40
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,99
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,3
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,6
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,16
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,4
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,2
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,4
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,9
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,23
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,2
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,3
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,4
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,6
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,8
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,13
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,27
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,55
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,135
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,1
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,2
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,2
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,3
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,3
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,4
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,5
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,7
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,8
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,10
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,12
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,16
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,21
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,29
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,46
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,95
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,189
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,462
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,1
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,1
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,2
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,2
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,3
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,4
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,4
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,5
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,7
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,8
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,10
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,13
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,18
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,25
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,39
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,80
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,159
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,388
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,1
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,2
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,3
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,4
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,5
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,8
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,18
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,36
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,88
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,2
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,5
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,14
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,3
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,2
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,4
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,11
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,2
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,2
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,4
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,6
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,13
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,27
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,67
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,1
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,1
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,1
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,2
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,2
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,3
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,4
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,5
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,6
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,7
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,10
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,14
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,22
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,46
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,93
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,228
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,1
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,1
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,1
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,2
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,2
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,3
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,4
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,5
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,6
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,8
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,12
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,19
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,39
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,78
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,192
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,2
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,4
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,8
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,17
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,44
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,1
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,2
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,7
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,1
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,1
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,1
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,1
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,2
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,3
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,5
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,10
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,21
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,53
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,1
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,1
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,1
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,2
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,2
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,3
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,3
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,4
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,5
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,6
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,8
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,10
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,14
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,19
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,31
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,64
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,128
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,314
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,1
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,2
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,3
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,4
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,6
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,7
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,9
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,11
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,13
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,16
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,19
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,23
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,29
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,37
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,49
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,69
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,107
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,220
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,439
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,1075
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,1
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,2
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,3
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,4
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,5
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,6
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,7
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,9
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,11
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,13
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,16
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,20
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,25
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,31
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,41
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,58
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,90
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,185
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,369
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,902
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,1
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,1
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,1
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,2
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,2
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,2
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,3
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,4
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,5
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,7
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,9
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,12
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,20
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,41
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,83
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,203
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,1
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,1
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,2
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,3
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,6
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,13
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,33
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,1
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,3
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,8
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,3
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,7
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,19
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,2
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,3
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,5
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,7
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,10
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,22
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,45
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,110
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,1
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,2
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,2
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,3
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,3
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,4
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,5
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,6
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,8
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,10
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,13
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,17
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,24
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,37
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,77
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,153
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,375
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,1
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,1
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,2
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,2
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,3
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,3
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,4
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,5
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,7
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,8
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,11
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,14
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,20
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,31
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,65
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,129
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,314
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,2
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,3
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,4
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,7
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,14
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,29
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,71
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,2
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,4
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,12
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,3
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,2
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,5
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,14
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,2
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,2
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,3
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,5
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,8
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,16
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,33
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,82
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,1
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,1
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,1
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,2
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,2
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,3
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,4
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,4
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,6
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,7
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,9
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,12
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,17
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,27
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,56
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,113
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,278
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,1
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,1
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,2
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,2
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,3
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,4
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,5
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,6
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,8
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,10
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,14
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,23
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,47
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,95
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,234
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,2
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,3
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,5
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,10
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,21
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,53
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,1
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,3
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,8
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,2
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,1
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,2
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,4
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,9
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,24
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,2
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,2
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,3
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,3
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,4
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,6
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,9
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,14
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,29
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,58
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,141
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,1
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,2
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,2
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,3
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,4
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,5
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,6
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,7
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,8
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,10
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,13
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,17
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,22
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,31
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,49
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,99
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,198
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,482
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,1
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,1
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,1
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,2
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,2
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,3
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,4
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,5
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,6
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,7
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,9
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,11
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,14
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,19
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,26
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,41
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,84
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,166
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,404
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,1
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,2
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,3
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,4
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,5
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,9
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,19
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,37
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,92
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,3
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,6
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,15
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,4
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,3
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,7
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,1
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,2
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,4
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,8
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,17
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,43
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,1
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,1
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,1
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,2
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,2
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,3
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,3
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,5
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,6
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,9
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,14
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,30
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,59
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,146
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,1
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,1
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,1
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,2
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,2
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,3
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,4
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,5
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,7
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,12
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,25
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,50
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,122
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,2
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,5
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,11
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,28
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,1
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,4
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,1
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,1
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,1
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,1
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,2
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,3
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,4
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,7
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,14
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,29
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,72
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,1
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,1
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,1
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,2
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,2
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,3
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,4
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,5
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,6
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,7
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,9
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,11
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,14
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,19
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,27
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,42
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,88
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,175
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,430
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,1
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,2
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,3
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,5
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,6
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,8
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,10
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,12
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,15
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,18
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,22
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,27
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,33
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,40
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,51
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,68
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,95
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,147
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,302
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,603
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,1474
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,1
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,2
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,3
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,4
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,5
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,7
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,8
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,10
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,13
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,15
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,18
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,22
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,27
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,34
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,43
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,57
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,80
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,124
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,254
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,506
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,1236
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,1
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,1
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,1
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,2
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,2
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,3
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,4
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,5
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,6
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,7
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,9
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,12
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,17
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,27
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,57
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,113
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,278
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,1
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,1
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,1
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,2
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,4
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,9
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,18
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,45
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,1
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,2
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,4
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,12
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,0
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,0
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,0
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,0
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,0
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,0
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,0
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,1
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,3
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,0
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,0
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,0
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,0
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,0
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,0
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,0
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,0
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,0
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,0
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,1
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,2
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,5
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,12
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,0
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,0
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,0
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,0
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,0
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,0
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,0
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,0
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,0
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,1
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,2
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,4
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,10
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,2
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,2
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,5
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,14
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,2
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,2
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,3
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,5
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,8
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,16
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,33
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,82
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,1
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,1
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,1
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,2
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,2
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,3
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,4
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,5
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,6
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,7
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,9
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,12
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,17
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,27
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,57
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,114
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,280
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,1
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,1
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,1
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,2
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,2
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,3
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,4
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,5
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,6
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,8
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,10
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,15
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,23
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,48
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,96
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,235
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,2
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,3
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,5
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,10
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,21
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,53
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,1
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,3
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,8
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,2
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,3
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,9
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,2
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,3
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,5
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,11
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,22
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,56
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,1
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,1
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,1
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,1
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,2
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,2
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,3
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,4
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,5
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,6
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,8
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,12
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,18
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,38
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,77
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,190
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,1
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,1
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,1
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,1
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,2
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,2
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,3
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,4
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,5
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,7
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,10
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,15
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,32
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,65
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,160
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,2
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,3
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,7
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,14
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,36
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,1
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,2
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,6
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,1
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,2
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,4
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,9
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,23
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,2
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,3
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,4
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,6
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,8
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,13
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,28
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,57
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,140
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,1
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,2
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,2
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,3
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,4
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,4
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,5
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,7
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,8
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,10
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,13
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,16
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,21
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,30
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,47
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,97
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,195
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,478
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,1
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,1
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,2
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,2
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,3
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,4
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,4
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,5
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,7
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,8
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,10
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,13
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,18
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,25
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,40
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,82
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,164
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,401
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,1
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,2
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,3
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,4
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,5
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,8
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,18
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,37
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,91
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,2
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,6
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,15
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,3
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,3
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,7
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,18
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,2
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,3
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,4
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,6
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,10
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,21
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,43
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,107
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,1
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,2
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,2
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,3
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,3
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,4
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,5
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,6
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,8
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,9
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,12
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,16
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,23
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,36
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,74
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,148
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,364
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,1
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,1
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,2
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,2
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,3
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,3
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,4
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,5
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,6
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,8
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,10
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,14
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,19
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,30
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,62
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,125
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,305
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,2
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,3
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,4
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,6
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,14
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,28
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,69
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,2
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,4
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,11
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,2
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,1
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,1
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,1
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,2
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,3
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,4
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,10
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,20
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,50
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,1
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,1
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,2
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,2
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,3
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,3
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,4
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,5
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,6
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,8
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,10
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,13
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,19
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,29
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,60
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,121
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,295
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,1
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,2
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,3
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,4
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,5
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,7
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,8
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,10
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,12
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,15
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,18
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,22
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,28
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,36
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,47
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,65
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,102
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,209
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,415
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,1011
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,1
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,2
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,3
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,4
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,5
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,6
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,7
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,9
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,10
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,13
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,15
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,19
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,23
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,30
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,39
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,55
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,86
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,175
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,348
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,847
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,1
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,1
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,1
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,1
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,2
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,2
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,3
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,4
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,5
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,6
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,8
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,12
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,19
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,39
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,78
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,191
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,1
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,1
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,1
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,3
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,6
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,12
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,31
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,1
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,3
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,8
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,2
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,4
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,9
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,23
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,2
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,3
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,4
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,6
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,8
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,13
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,27
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,55
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,135
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,1
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,2
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,2
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,3
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,3
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,4
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,5
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,6
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,8
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,10
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,12
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,16
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,21
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,29
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,46
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,94
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,188
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,459
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,1
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,1
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,2
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,2
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,3
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,3
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,4
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,5
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,7
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,8
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,10
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,13
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,17
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,24
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,38
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,79
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,158
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,385
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,1
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,2
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,2
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,3
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,5
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,8
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,17
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,35
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,87
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,2
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,5
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,14
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,3
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,2
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,6
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,0
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,1
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,2
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,3
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,7
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,14
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,35
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,0
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,1
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,1
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,1
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,2
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,2
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,3
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,4
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,5
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,7
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,11
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,24
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,48
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,119
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,0
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,1
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,1
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,1
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,2
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,2
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,3
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,4
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,6
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,9
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,20
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,40
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,100
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,2
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,4
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,9
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,23
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,1
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,3
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,1
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,1
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,2
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,3
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,7
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,14
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,35
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,1
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,1
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,2
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,2
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,2
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,3
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,4
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,5
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,7
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,9
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,13
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,20
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,42
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,84
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,207
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,1
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,1
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,2
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,3
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,4
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,4
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,6
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,7
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,8
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,10
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,12
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,15
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,19
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,24
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,32
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,45
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,70
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,145
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,289
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,708
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,1
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,2
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,2
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,3
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,4
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,5
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,6
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,7
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,8
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,10
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,13
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,16
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,20
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,27
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,38
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,59
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,122
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,243
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,594
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,1
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,1
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,1
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,2
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,2
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,3
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,4
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,6
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,8
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,13
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,27
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,54
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,134
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,1
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,2
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,4
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,8
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,22
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,1
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,2
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,5
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,2
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,4
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,11
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,2
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,2
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,4
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,6
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,13
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,26
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,65
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,1
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,1
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,1
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,2
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,2
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,3
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,3
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,4
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,5
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,7
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,10
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,14
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,21
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,45
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,90
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,220
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,1
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,1
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,1
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,2
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,2
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,3
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,4
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,5
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,6
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,8
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,11
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,18
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,37
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,75
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,185
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,2
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,4
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,8
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,17
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,42
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,1
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,2
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,7
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,1
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,0
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,0
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,0
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,0
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,0
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,0
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,0
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,1
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,2
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,0
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,0
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,0
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,0
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,0
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,0
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,0
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,0
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,0
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,0
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,0
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,1
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,3
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,9
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,0
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,0
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,0
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,0
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,0
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,0
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,0
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,0
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,0
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,0
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,1
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,3
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,7
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,0
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,0
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,0
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,0
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,1
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,2
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,5
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,14
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,2
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,2
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,3
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,5
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,8
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,17
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,34
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,84
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,1
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,1
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,1
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,2
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,2
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,3
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,4
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,5
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,6
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,7
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,9
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,13
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,18
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,28
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,58
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,116
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,285
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,1
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,1
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,1
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,2
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,2
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,3
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,4
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,5
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,6
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,8
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,11
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,15
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,24
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,49
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,98
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,239
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,2
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,3
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,5
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,11
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,22
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,54
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,1
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,3
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,9
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,2
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,2
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,4
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,8
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,21
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,2
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,3
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,4
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,5
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,7
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,12
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,25
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,50
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,121
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,1
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,1
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,2
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,2
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,3
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,4
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,5
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,6
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,7
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,9
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,11
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,14
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,19
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,27
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,42
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,85
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,170
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,413
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,1
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,1
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,2
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,3
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,3
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,4
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,5
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,6
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,7
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,9
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,12
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,16
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,22
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,35
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,72
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,143
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,346
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,2
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,2
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,3
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,5
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,7
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,16
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,32
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,79
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,2
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,5
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,13
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,3
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,1
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,1
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,2
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,3
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,6
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,13
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,33
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,1
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,1
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,2
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,2
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,3
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,4
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,5
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,6
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,9
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,12
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,19
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,40
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,81
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,198
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,1
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,1
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,2
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,3
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,3
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,4
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,5
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,7
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,8
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,10
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,12
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,15
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,18
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,23
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,31
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,43
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,67
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,139
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,277
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,679
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,1
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,1
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,2
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,3
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,4
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,4
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,5
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,7
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,8
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,10
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,12
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,15
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,20
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,26
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,36
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,57
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,117
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,233
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,569
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,1
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,1
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,1
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,2
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,2
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,3
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,4
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,5
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,8
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,12
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,26
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,52
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,128
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,1
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,2
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,4
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,8
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,21
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,1
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,2
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,5
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,3
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,7
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,1
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,2
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,4
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,8
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,17
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,43
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,1
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,1
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,1
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,2
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,2
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,3
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,4
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,5
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,6
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,9
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,14
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,30
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,60
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,147
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,1
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,1
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,1
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,2
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,2
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,3
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,4
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,5
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,7
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,12
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,25
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,51
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,124
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,2
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,5
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,11
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,28
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,1
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,4
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,1
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,2
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,5
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,14
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,2
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,2
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,3
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,5
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,7
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,16
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,33
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,81
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,1
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,1
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,1
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,2
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,2
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,3
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,4
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,4
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,5
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,7
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,9
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,12
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,17
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,27
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,56
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,113
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,279
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,1
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,1
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,2
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,2
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,3
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,4
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,5
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,6
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,7
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,10
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,14
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,23
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,47
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,95
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,234
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,2
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,3
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,5
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,10
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,21
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,53
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,1
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,3
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,8
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,2
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,4
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,8
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,20
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,2
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,3
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,4
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,5
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,7
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,11
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,24
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,49
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,121
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,1
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,1
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,2
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,2
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,3
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,4
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,5
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,6
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,7
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,9
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,11
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,14
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,18
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,26
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,41
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,84
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,168
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,413
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,1
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,1
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,2
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,2
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,3
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,4
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,5
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,6
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,7
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,9
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,12
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,15
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,22
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,34
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,70
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,141
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,347
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,2
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,2
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,3
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,4
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,7
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,16
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,32
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,78
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,2
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,5
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,13
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,3
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,1
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,2
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,6
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,12
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,30
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,1
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,2
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,2
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,3
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,3
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,4
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,6
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,8
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,11
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,17
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,36
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,72
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,178
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,1
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,1
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,2
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,2
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,3
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,4
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,5
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,6
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,7
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,9
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,11
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,13
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,16
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,21
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,28
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,39
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,61
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,124
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,249
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,608
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,1
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,1
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,2
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,2
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,3
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,4
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,5
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,6
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,7
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,9
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,11
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,14
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,18
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,23
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,33
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,51
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,105
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,209
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,510
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,1
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,1
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,2
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,2
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,3
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,3
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,5
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,7
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,11
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,23
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,47
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,115
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,1
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,3
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,7
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,19
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,5
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,1
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,4
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,1
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,1
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,2
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,4
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,9
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,24
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,0
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,0
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,0
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,1
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,1
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,1
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,2
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,2
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,3
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,5
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,8
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,16
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,33
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,82
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,0
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,0
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,0
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,1
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,1
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,1
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,2
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,3
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,4
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,6
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,14
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,28
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,69
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,1
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,3
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,6
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,16
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,1
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,2
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,2
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,4
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,9
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,23
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,2
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,3
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,4
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,6
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,8
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,13
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,27
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,55
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,136
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,1
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,2
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,2
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,3
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,3
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,4
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,5
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,6
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,8
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,10
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,12
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,16
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,21
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,29
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,46
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,94
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,189
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,463
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,1
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,1
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,2
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,2
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,3
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,3
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,4
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,5
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,7
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,8
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,10
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,13
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,17
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,25
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,39
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,79
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,159
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,389
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,1
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,2
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,2
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,3
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,5
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,8
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,18
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,36
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,88
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,2
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,5
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,14
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,3
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,1
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,1
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,3
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,8
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,1
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,1
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,2
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,5
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,10
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,26
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,1
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,2
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,4
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,9
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,22
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,2
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,5
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,3
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,7
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,1
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,2
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,4
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,9
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,18
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,44
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,1
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,1
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,1
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,2
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,2
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,3
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,4
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,5
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,6
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,9
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,15
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,30
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,61
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,150
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,1
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,1
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,1
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,1
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,2
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,2
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,3
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,4
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,5
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,8
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,12
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,26
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,52
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,126
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,2
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,5
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,11
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,29
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,1
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,4
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,1
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,2
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,4
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,9
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,22
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,2
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,3
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,4
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,5
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,8
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,12
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,26
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,53
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,131
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,1
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,1
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,2
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,3
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,3
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,4
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,5
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,6
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,7
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,9
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,12
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,15
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,20
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,28
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,44
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,91
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,183
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,449
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,1
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,1
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,2
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,2
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,3
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,3
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,4
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,5
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,6
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,8
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,10
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,13
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,17
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,23
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,37
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,76
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,153
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,378
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,2
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,2
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,3
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,5
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,8
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,17
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,34
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,85
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,2
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,5
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,14
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,3
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,3
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,6
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,16
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,2
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,3
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,4
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,6
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,9
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,19
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,38
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,94
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,1
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,1
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,2
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,2
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,3
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,4
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,4
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,5
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,7
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,8
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,11
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,14
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,20
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,32
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,66
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,131
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,320
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,1
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,1
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,2
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,2
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,3
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,4
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,4
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,6
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,7
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,9
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,12
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,17
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,27
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,55
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,110
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,268
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,2
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,2
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,3
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,6
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,12
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,25
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,61
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,2
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,4
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,10
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,2
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,1
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,1
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,1
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,2
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,2
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,3
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,3
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,4
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,5
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,7
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,9
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,13
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,20
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,42
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,84
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,205
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,1
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,2
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,3
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,4
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,5
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,7
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,8
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,10
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,12
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,15
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,18
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,22
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,27
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,34
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,43
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,56
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,79
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,123
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,252
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,503
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,1230
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,1
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,2
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,4
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,7
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,11
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,15
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,20
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,25
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,30
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,37
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,44
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,53
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,64
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,78
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,95
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,118
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,149
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,196
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,273
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,425
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,869
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,1731
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,4222
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,1
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,3
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,6
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,9
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,13
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,17
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,21
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,25
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,31
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,37
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,45
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,54
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,66
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,80
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,99
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,126
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,165
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,230
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,358
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,731
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,1453
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,3540
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,1
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,2
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,2
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,3
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,4
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,5
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,6
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,8
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,10
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,12
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,14
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,17
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,22
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,28
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,37
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,51
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,80
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,163
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,325
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,793
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,1
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,1
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,1
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,1
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,2
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,2
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,3
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,4
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,5
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,8
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,12
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,26
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,52
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,128
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,1
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,1
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,2
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,3
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,6
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,13
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,33
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,3
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,8
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,2
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,3
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,5
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,10
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,21
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,52
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,1
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,1
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,1
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,2
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,2
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,3
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,3
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,4
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,5
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,7
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,11
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,17
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,35
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,71
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,177
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,1
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,1
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,1
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,2
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,2
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,3
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,3
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,5
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,6
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,9
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,14
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,30
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,60
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,149
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,2
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,3
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,6
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,13
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,34
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,1
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,2
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,5
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,1
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,1
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,0
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,0
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,0
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,0
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,0
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,1
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,3
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,9
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,0
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,0
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,0
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,0
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,0
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,0
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,0
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,1
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,1
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,2
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,3
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,6
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,13
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,32
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,0
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,0
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,0
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,0
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,0
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,0
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,0
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,1
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,1
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,2
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,5
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,11
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,27
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,1
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,2
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,6
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,1
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,3
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,9
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,2
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,3
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,5
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,11
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,22
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,55
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,1
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,1
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,1
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,2
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,2
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,3
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,4
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,5
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,6
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,8
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,11
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,18
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,38
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,76
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,187
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,1
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,1
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,1
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,1
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,2
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,2
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,3
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,4
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,5
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,7
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,10
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,15
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,32
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,64
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,157
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,2
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,3
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,7
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,14
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,36
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,1
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,2
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,5
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,1
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,2
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,6
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,0
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,1
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,2
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,3
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,8
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,16
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,40
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,1
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,1
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,1
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,1
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,2
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,2
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,3
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,4
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,6
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,8
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,13
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,27
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,55
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,135
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,1
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,1
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,1
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,1
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,2
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,3
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,3
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,5
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,7
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,11
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,23
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,46
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,113
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,2
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,5
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,10
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,26
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,1
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,4
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,1
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,1
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,0
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,0
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,0
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,0
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,0
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,1
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,3
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,8
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,0
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,0
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,0
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,0
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,0
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,0
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,0
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,0
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,1
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,1
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,2
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,5
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,11
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,27
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,0
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,0
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,0
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,0
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,0
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,0
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,0
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,0
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,1
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,2
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,4
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,9
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,22
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,0
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,0
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,1
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,2
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,5
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,2
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,4
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,11
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,2
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,2
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,4
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,6
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,13
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,27
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,67
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,1
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,1
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,1
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,2
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,2
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,3
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,4
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,5
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,6
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,7
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,10
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,14
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,22
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,47
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,93
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,230
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,1
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,1
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,1
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,2
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,2
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,3
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,4
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,5
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,6
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,8
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,12
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,19
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,39
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,79
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,193
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,2
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,4
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,8
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,18
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,44
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,1
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,2
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,7
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,1
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,2
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,6
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,0
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,1
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,2
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,3
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,7
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,14
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,36
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,0
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,1
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,1
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,1
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,2
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,2
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,3
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,4
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,5
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,7
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,12
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,25
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,50
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,122
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,0
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,1
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,1
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,1
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,2
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,2
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,3
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,4
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,6
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,10
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,21
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,42
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,103
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,2
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,4
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,9
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,23
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,1
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,3
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0

--- a/data-forecasts/sentinel-gamlss/metadata-sentinel-gamlss.txt
+++ b/data-forecasts/sentinel-gamlss/metadata-sentinel-gamlss.txt
@@ -1,0 +1,13 @@
+
+team_name: Sentinel
+model_name: GAMLSS ZIBNB
+model_abbr: sentinel-gamlss
+model_contributors: Simon Frost (Microsoft Premonition) <sdwfrost@microsoft.com>, Rory Gibb (UCL) <rory.gibb.14@ucl.ac.uk>, Natalie Imirzian (Institute of Zoology) <natalie.imirzian@ioz.ac.uk>, Kate Jones (UCL) <kate.e.jones@ucl.ac.uk>, David Redding (Institute of Zoology) <dwredding@gmail.com>
+website_url: https://github.com/sdwfrost/WNV-forecast-project-2023
+license: cc-by-4.0
+team_model_designation: primary
+methods: GAMLSS model with state and month as categorical variables, with case count modeled as a zero-inflated beta negative binomial distribution.
+ensemble_of_hub_models: false
+data_inputs: No additional covariates.
+team_funding: Microsoft and The Trinity Challenge.
+

--- a/data-forecasts/sentinel-hhh4/2023-05-31-sentinel-hhh4.csv
+++ b/data-forecasts/sentinel-hhh4/2023-05-31-sentinel-hhh4.csv
@@ -1,0 +1,7890 @@
+location,forecast_date,target_end_date,target,type,quantile,value
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,2
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,3
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,2
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,3
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,3
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,4
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,5
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,7
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,8
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,11
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,1
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,1
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,2
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,2
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,3
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,4
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,4
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,5
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,6
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,7
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,9
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,11
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,13
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,16
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,22
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,28
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,37
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,1
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,1
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,1
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,2
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,2
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,3
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,3
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,4
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,5
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,6
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,8
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,10
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,14
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,19
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,26
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,2
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,2
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,3
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,5
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,7
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,11
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,2
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,3
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,5
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,2
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,2
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,3
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,2
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,2
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,3
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,4
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,5
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,7
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,9
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,11
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,1
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,1
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,2
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,2
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,3
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,4
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,4
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,5
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,6
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,7
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,9
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,11
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,13
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,16
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,22
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,28
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,36
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,1
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,1
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,1
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,2
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,2
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,3
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,3
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,4
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,5
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,6
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,8
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,10
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,14
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,19
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,26
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,2
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,2
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,3
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,5
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,8
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,12
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,2
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,3
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,5
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,2
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,1
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,1
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,1
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,1
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,2
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,2
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,3
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,3
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,4
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,5
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,6
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,9
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,11
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,14
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,1
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,1
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,2
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,3
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,4
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,5
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,7
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,8
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,10
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,12
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,15
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,17
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,20
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,24
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,29
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,35
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,44
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,59
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,74
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,96
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,1
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,3
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,5
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,8
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,12
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,16
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,20
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,26
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,31
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,38
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,45
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,54
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,63
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,75
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,88
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,103
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,126
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,155
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,206
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,263
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,338
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,1
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,3
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,4
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,6
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,8
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,10
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,13
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,16
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,19
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,23
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,28
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,33
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,39
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,47
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,57
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,70
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,90
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,128
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,171
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,230
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,1
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,1
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,2
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,2
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,3
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,3
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,4
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,5
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,6
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,8
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,10
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,13
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,18
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,25
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,44
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,68
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,107
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,1
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,1
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,1
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,2
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,2
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,3
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,4
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,6
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,12
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,20
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,35
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,1
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,1
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,1
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,2
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,3
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,6
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,11
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,1
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,1
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,1
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,2
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,2
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,2
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,3
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,3
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,4
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,5
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,6
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,8
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,10
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,13
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,17
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,1
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,2
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,3
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,4
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,5
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,7
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,8
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,10
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,12
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,15
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,18
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,21
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,25
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,29
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,35
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,42
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,54
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,74
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,93
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,117
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,1
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,4
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,7
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,10
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,14
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,19
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,24
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,30
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,37
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,44
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,52
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,62
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,74
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,87
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,104
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,123
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,149
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,189
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,257
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,323
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,416
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,2
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,3
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,5
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,7
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,9
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,12
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,15
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,19
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,23
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,27
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,33
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,39
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,47
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,57
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,69
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,84
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,108
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,157
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,212
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,305
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,1
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,1
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,1
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,2
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,3
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,3
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,4
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,5
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,7
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,8
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,10
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,13
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,17
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,23
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,32
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,54
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,84
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,130
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,1
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,1
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,1
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,1
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,2
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,3
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,4
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,5
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,8
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,14
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,24
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,41
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,1
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,1
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,1
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,2
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,4
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,7
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,14
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,1
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,1
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,1
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,1
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,2
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,2
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,3
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,4
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,6
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,1
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,1
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,2
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,2
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,3
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,3
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,4
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,5
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,6
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,7
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,8
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,10
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,12
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,15
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,20
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,26
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,34
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,1
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,2
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,3
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,4
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,5
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,7
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,8
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,10
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,12
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,15
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,17
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,20
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,24
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,29
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,34
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,41
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,52
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,70
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,88
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,114
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,1
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,1
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,2
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,2
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,3
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,4
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,5
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,6
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,7
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,9
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,11
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,13
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,16
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,19
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,24
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,31
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,44
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,60
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,82
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,1
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,1
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,1
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,2
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,2
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,3
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,4
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,5
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,6
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,9
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,16
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,24
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,37
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,1
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,1
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,2
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,2
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,4
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,7
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,13
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,1
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,1
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,2
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,5
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,1
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,1
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,1
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,1
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,2
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,3
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,3
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,4
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,1
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,1
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,1
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,1
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,2
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,2
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,2
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,3
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,3
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,4
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,6
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,8
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,10
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,13
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,0
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,0
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,1
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,1
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,1
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,1
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,2
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,2
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,3
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,3
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,5
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,7
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,9
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,1
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,2
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,3
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,5
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,1
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,1
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,2
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,1
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,1
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,1
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,1
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,1
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,2
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,2
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,3
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,4
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,0
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,1
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,1
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,1
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,1
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,2
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,2
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,2
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,3
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,4
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,5
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,7
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,8
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,11
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,0
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,0
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,0
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,1
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,1
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,1
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,1
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,2
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,2
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,3
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,4
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,6
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,8
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,1
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,2
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,3
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,4
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,1
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,2
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,1
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,1
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,1
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,1
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,1
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,2
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,0
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,0
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,0
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,0
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,0
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,0
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,1
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,1
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,1
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,1
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,2
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,3
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,3
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,4
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,1
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,1
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,1
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,2
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,3
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,3
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,1
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,1
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,2
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,1
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,1
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,2
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,3
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,2
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,2
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,3
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,4
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,4
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,6
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,8
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,10
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,13
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,1
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,2
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,2
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,3
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,3
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,4
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,5
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,6
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,7
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,8
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,10
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,12
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,15
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,19
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,26
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,33
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,41
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,1
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,1
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,2
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,2
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,3
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,3
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,4
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,5
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,6
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,7
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,8
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,11
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,16
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,22
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,30
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,2
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,2
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,3
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,6
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,9
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,13
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,1
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,2
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,3
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,5
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,2
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,2
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,2
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,2
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,2
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,3
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,4
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,5
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,6
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,8
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,11
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,1
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,1
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,2
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,2
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,3
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,3
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,4
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,5
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,6
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,7
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,8
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,10
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,12
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,16
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,21
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,27
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,35
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,1
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,1
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,1
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,2
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,2
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,2
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,3
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,4
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,5
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,6
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,7
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,9
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,13
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,18
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,26
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,2
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,3
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,5
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,7
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,11
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,2
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,3
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,5
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,2
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,2
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,2
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,2
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,2
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,3
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,4
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,5
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,6
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,8
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,10
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,1
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,1
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,2
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,2
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,3
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,3
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,4
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,5
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,6
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,7
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,8
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,10
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,12
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,14
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,20
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,26
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,33
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,1
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,1
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,1
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,2
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,2
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,2
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,3
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,4
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,4
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,5
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,7
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,9
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,13
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,17
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,23
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,2
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,3
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,4
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,7
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,11
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,1
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,3
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,5
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,2
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,1
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,2
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,2
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,2
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,3
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,4
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,5
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,7
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,1
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,1
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,1
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,2
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,2
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,3
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,3
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,4
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,5
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,5
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,7
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,8
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,10
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,13
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,17
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,22
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,1
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,1
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,1
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,1
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,2
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,2
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,2
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,3
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,4
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,4
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,6
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,8
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,11
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,16
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,2
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,3
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,5
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,8
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,1
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,2
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,3
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,1
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,1
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,1
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,1
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,1
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,1
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,2
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,2
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,3
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,4
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,6
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,1
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,1
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,1
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,2
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,2
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,3
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,3
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,4
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,5
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,6
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,7
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,8
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,10
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,12
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,15
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,20
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,26
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,34
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,1
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,2
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,3
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,4
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,5
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,7
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,9
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,10
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,13
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,15
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,18
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,21
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,24
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,29
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,35
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,43
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,53
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,70
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,89
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,116
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,1
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,1
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,2
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,3
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,3
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,4
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,5
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,6
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,8
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,9
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,11
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,13
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,16
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,19
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,24
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,31
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,45
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,59
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,83
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,1
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,1
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,1
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,2
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,2
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,3
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,4
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,5
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,7
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,9
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,16
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,25
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,39
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,1
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,1
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,2
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,2
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,5
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,8
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,14
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,1
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,1
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,2
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,4
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,2
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,2
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,2
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,3
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,3
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,4
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,5
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,7
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,9
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,12
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,1
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,1
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,2
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,2
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,3
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,4
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,4
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,5
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,6
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,8
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,9
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,11
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,14
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,17
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,23
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,30
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,38
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,1
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,1
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,1
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,2
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,2
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,3
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,3
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,4
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,5
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,6
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,8
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,10
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,14
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,19
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,26
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,2
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,2
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,3
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,5
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,8
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,13
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,2
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,3
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,5
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,1
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,2
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,1
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,2
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,3
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,2
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,2
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,3
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,3
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,4
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,6
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,8
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,10
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,13
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,1
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,2
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,2
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,3
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,3
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,4
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,5
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,6
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,7
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,8
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,10
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,12
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,15
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,19
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,25
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,32
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,40
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,1
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,1
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,2
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,2
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,3
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,3
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,4
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,5
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,6
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,7
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,9
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,11
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,16
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,22
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,31
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,2
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,2
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,3
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,6
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,9
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,14
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,1
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,2
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,3
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,5
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,1
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,2
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,1
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,1
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,1
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,2
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,2
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,3
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,4
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,5
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,1
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,1
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,1
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,1
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,2
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,2
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,2
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,3
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,4
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,4
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,5
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,7
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,9
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,12
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,15
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,0
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,1
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,1
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,1
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,1
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,2
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,2
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,2
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,3
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,4
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,6
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,8
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,11
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,1
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,2
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,3
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,6
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,1
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,1
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,2
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,1
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,1
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,1
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,1
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,1
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,2
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,2
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,3
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,4
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,5
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,7
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,1
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,1
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,1
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,2
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,3
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,3
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,4
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,5
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,6
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,7
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,8
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,10
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,12
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,14
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,18
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,24
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,31
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,41
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,1
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,2
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,3
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,4
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,6
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,8
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,10
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,12
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,15
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,17
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,20
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,24
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,28
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,33
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,39
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,48
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,61
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,83
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,106
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,136
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,1
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,1
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,2
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,3
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,4
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,5
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,6
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,7
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,9
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,11
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,13
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,15
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,18
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,22
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,27
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,36
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,52
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,71
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,100
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,1
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,1
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,1
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,2
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,2
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,3
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,3
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,4
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,6
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,8
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,11
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,18
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,28
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,44
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,1
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,1
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,1
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,2
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,3
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,5
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,9
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,16
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,1
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,2
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,3
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,5
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,1
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,1
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,1
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,2
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,2
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,3
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,4
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,5
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,1
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,1
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,1
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,1
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,2
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,2
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,3
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,3
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,4
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,5
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,6
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,7
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,10
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,13
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,17
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,0
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,1
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,1
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,1
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,1
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,2
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,2
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,3
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,3
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,4
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,6
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,9
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,12
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,1
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,2
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,4
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,6
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,1
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,1
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,2
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,1
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,1
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,2
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,2
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,2
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,3
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,3
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,5
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,6
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,8
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,1
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,1
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,1
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,2
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,2
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,3
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,3
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,4
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,5
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,6
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,7
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,9
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,11
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,15
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,20
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,25
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,1
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,1
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,1
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,1
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,2
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,2
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,3
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,3
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,4
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,5
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,7
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,10
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,13
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,19
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,2
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,4
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,5
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,9
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,1
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,2
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,4
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,2
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,1
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,1
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,1
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,1
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,1
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,2
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,1
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,1
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,2
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,1
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,1
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,1
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,2
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,3
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,4
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,1
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,1
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,2
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,2
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,3
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,3
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,4
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,5
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,6
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,7
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,9
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,11
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,15
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,18
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,1
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,2
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,2
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,3
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,4
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,5
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,6
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,8
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,9
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,11
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,13
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,16
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,19
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,23
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,29
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,40
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,51
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,64
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,1
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,2
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,2
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,3
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,3
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,4
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,5
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,6
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,7
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,9
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,10
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,13
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,17
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,24
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,32
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,46
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,2
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,3
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,4
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,5
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,9
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,13
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,21
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,1
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,1
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,3
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,5
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,8
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,1
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,2
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,3
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,2
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,3
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,2
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,2
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,3
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,3
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,4
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,5
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,7
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,9
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,12
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,1
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,1
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,2
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,2
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,3
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,4
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,5
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,5
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,7
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,8
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,9
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,11
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,14
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,17
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,23
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,30
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,37
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,1
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,1
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,2
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,2
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,2
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,3
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,4
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,4
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,5
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,6
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,8
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,10
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,15
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,20
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,29
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,2
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,2
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,3
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,5
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,8
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,13
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,2
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,3
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,5
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,1
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,2
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,1
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,2
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,2
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,3
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,2
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,3
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,3
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,4
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,5
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,6
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,9
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,11
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,14
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,1
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,2
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,2
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,3
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,4
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,5
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,6
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,7
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,8
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,10
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,12
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,14
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,17
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,21
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,29
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,37
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,47
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,1
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,1
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,2
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,2
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,2
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,3
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,4
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,4
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,5
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,6
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,8
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,9
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,12
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,18
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,25
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,36
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,2
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,3
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,4
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,6
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,10
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,16
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,1
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,2
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,3
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,6
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,1
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,3
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,1
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,1
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,1
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,1
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,2
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,2
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,3
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,3
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,5
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,6
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,1
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,1
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,1
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,2
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,2
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,3
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,4
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,4
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,5
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,6
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,7
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,9
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,11
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,13
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,16
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,22
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,28
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,36
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,1
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,2
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,3
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,4
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,6
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,7
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,9
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,11
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,13
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,16
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,19
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,22
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,26
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,31
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,37
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,44
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,56
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,76
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,97
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,125
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,1
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,1
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,2
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,2
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,3
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,4
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,5
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,7
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,8
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,10
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,12
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,14
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,17
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,20
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,26
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,33
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,49
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,65
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,91
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,1
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,1
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,1
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,2
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,2
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,3
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,4
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,5
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,7
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,10
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,16
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,24
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,41
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,1
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,1
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,1
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,2
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,3
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,5
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,8
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,15
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,1
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,1
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,3
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,5
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,1
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,1
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,1
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,2
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,2
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,3
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,4
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,5
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,1
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,1
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,1
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,1
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,2
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,2
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,3
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,3
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,4
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,5
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,6
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,7
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,10
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,13
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,16
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,0
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,1
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,1
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,1
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,1
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,2
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,2
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,3
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,3
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,4
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,6
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,9
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,12
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,1
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,2
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,4
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,6
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,1
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,2
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,3
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,1
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,1
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,1
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,1
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,1
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,2
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,2
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,3
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,4
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,0
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,1
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,1
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,1
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,1
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,2
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,2
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,3
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,3
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,4
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,5
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,7
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,9
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,11
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,0
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,0
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,1
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,1
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,1
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,1
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,1
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,2
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,2
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,3
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,4
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,6
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,8
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,1
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,2
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,3
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,4
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,1
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,1
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,2
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,1
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,1
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,2
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,3
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,2
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,2
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,3
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,4
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,4
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,6
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,8
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,10
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,13
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,1
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,1
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,2
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,3
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,3
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,4
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,5
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,6
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,7
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,8
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,10
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,12
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,15
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,18
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,25
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,32
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,40
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,1
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,1
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,2
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,2
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,3
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,3
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,4
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,5
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,5
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,7
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,8
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,11
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,16
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,21
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,30
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,2
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,2
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,3
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,6
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,9
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,14
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,1
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,2
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,3
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,6
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,1
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,2
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,1
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,1
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,1
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,2
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,2
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,3
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,4
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,1
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,1
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,2
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,2
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,2
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,3
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,4
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,4
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,5
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,6
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,8
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,9
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,13
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,17
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,22
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,1
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,2
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,3
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,4
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,5
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,6
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,8
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,9
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,11
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,13
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,15
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,18
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,22
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,27
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,33
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,46
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,56
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,73
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,1
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,1
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,2
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,2
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,3
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,4
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,5
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,6
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,7
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,8
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,10
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,12
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,15
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,20
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,28
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,39
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,56
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,1
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,2
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,2
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,3
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,4
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,6
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,10
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,16
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,27
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,1
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,1
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,2
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,3
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,5
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,10
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,1
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,2
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,4
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,1
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,1
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,1
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,1
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,1
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,1
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,2
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,2
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,1
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,1
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,2
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,1
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,1
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,1
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,2
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,2
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,2
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,3
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,3
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,5
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,6
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,8
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,1
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,1
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,1
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,2
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,2
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,3
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,3
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,4
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,5
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,6
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,7
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,9
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,11
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,15
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,18
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,24
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,1
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,1
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,1
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,1
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,2
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,2
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,3
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,3
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,4
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,5
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,6
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,9
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,12
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,18
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,2
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,4
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,5
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,9
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,1
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,2
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,3
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,2
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,2
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,2
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,2
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,3
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,3
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,4
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,5
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,7
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,9
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,12
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,1
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,1
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,2
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,2
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,3
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,4
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,5
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,6
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,7
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,8
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,9
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,11
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,13
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,17
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,23
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,29
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,39
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,1
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,1
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,1
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,2
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,2
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,3
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,3
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,4
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,5
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,6
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,8
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,10
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,14
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,19
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,27
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,2
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,2
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,3
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,5
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,8
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,12
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,2
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,3
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,5
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,2
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,2
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,2
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,2
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,2
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,2
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,3
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,4
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,5
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,7
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,9
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,1
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,1
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,1
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,2
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,2
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,3
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,3
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,4
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,5
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,6
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,7
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,8
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,10
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,12
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,17
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,22
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,28
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,1
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,1
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,1
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,1
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,2
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,2
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,3
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,3
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,4
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,5
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,6
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,7
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,11
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,14
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,21
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,2
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,2
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,4
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,6
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,10
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,1
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,2
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,4
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,2
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,1
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,1
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,2
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,3
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,3
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,1
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,1
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,2
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,2
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,3
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,3
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,4
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,5
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,5
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,7
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,8
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,11
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,14
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,19
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,1
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,2
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,3
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,3
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,4
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,5
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,6
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,8
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,9
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,11
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,13
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,15
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,19
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,23
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,29
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,39
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,51
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,62
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,1
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,2
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,2
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,3
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,3
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,4
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,5
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,6
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,7
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,8
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,10
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,13
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,17
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,24
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,33
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,47
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,2
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,2
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,3
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,4
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,5
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,8
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,13
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,20
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,1
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,2
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,4
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,7
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,1
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,3
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,1
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,2
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,2
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,3
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,1
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,2
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,2
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,3
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,4
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,4
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,5
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,7
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,9
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,12
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,16
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,1
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,2
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,2
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,3
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,4
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,5
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,6
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,7
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,8
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,10
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,12
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,14
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,18
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,22
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,30
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,37
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,48
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,1
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,1
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,2
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,2
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,3
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,3
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,4
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,5
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,5
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,7
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,8
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,10
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,13
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,19
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,25
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,36
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,2
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,2
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,3
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,4
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,7
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,10
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,16
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,1
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,2
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,4
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,6
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,1
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,2
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,1
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,1
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,2
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,3
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,4
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,1
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,1
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,2
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,2
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,3
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,3
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,4
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,5
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,6
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,7
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,9
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,12
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,15
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,19
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,1
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,2
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,3
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,3
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,4
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,5
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,7
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,8
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,9
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,11
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,13
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,16
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,19
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,22
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,29
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,39
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,50
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,63
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,1
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,1
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,2
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,2
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,3
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,3
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,4
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,5
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,6
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,7
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,9
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,11
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,13
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,17
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,25
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,35
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,49
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,2
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,2
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,3
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,4
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,5
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,9
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,14
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,22
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,1
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,1
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,3
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,5
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,9
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,1
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,2
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,3
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,1
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,1
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,1
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,1
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,1
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,2
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,3
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,0
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,0
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,0
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,0
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,1
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,1
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,1
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,1
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,2
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,2
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,3
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,4
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,5
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,7
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,0
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,0
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,0
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,0
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,0
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,1
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,1
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,1
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,1
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,2
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,3
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,4
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,5
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,1
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,2
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,3
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,1
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,1
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,2
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,3
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,2
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,2
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,3
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,3
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,4
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,5
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,8
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,10
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,13
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,1
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,1
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,2
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,2
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,3
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,4
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,5
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,5
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,7
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,8
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,9
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,11
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,14
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,18
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,25
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,32
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,41
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,1
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,1
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,2
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,2
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,2
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,3
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,4
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,4
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,5
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,7
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,8
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,11
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,16
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,21
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,30
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,2
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,2
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,3
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,6
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,9
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,14
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,2
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,3
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,5
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,1
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,2
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,1
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,1
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,1
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,2
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,1
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,1
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,1
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,1
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,2
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,3
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,4
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,1
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,1
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,1
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,2
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,3
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,1
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,1
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,2
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,1
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,1
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,1
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,1
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,2
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,2
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,3
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,4
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,5
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,1
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,1
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,1
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,1
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,2
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,2
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,3
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,3
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,4
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,5
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,6
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,9
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,11
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,14
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,0
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,1
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,1
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,1
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,1
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,1
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,2
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,2
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,3
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,4
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,5
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,7
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,10
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,1
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,2
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,3
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,5
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,1
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,1
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,2
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,1
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,1
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,1
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,2
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,3
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,4
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,1
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,2
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,2
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,2
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,3
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,4
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,4
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,5
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,6
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,8
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,11
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,14
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,18
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,1
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,2
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,2
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,3
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,4
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,5
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,6
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,7
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,9
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,10
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,12
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,14
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,17
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,21
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,26
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,35
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,44
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,58
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,1
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,2
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,2
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,3
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,3
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,4
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,4
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,5
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,7
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,8
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,10
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,12
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,15
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,22
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,30
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,43
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,2
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,2
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,3
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,5
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,8
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,13
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,19
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,1
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,3
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,4
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,7
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,1
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,2
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,3
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,2
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,2
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,2
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,2
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,2
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,3
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,4
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,5
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,7
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,9
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,1
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,1
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,1
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,2
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,2
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,3
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,3
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,4
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,5
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,6
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,7
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,8
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,10
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,13
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,18
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,22
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,29
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,1
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,1
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,1
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,1
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,2
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,2
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,3
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,3
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,4
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,5
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,6
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,8
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,11
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,15
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,21
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,2
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,2
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,4
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,6
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,11
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,1
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,2
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,4
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,1
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,1
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,1
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,1
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,1
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,2
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,2
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,3
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,3
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,4
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,5
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,6
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,7
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,10
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,13
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,16
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,1
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,1
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,2
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,4
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,5
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,6
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,8
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,10
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,12
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,14
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,17
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,20
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,23
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,28
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,33
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,41
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,50
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,70
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,86
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,113
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,1
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,3
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,6
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,10
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,14
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,19
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,24
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,29
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,36
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,43
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,51
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,61
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,71
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,83
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,98
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,118
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,143
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,180
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,249
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,310
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,396
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,1
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,3
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,5
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,7
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,9
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,12
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,15
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,18
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,22
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,26
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,32
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,38
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,46
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,55
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,66
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,81
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,106
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,152
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,200
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,271
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,1
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,1
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,1
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,2
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,2
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,3
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,4
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,5
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,6
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,8
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,10
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,12
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,16
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,22
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,31
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,53
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,78
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,118
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,1
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,1
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,1
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,1
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,2
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,2
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,3
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,5
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,8
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,14
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,25
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,42
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,1
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,1
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,1
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,2
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,4
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,7
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,14
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,1
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,2
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,2
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,2
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,3
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,4
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,5
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,6
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,1
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,1
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,1
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,1
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,2
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,2
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,3
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,3
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,4
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,5
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,6
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,7
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,9
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,12
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,15
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,19
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,1
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,1
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,1
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,1
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,2
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,2
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,2
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,3
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,4
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,5
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,8
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,10
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,14
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,2
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,3
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,4
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,7
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,1
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,2
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,3
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,1
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,1
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,2
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,2
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,2
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,2
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,4
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,5
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,6
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,1
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,1
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,1
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,2
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,2
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,2
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,3
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,3
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,4
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,5
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,6
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,8
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,11
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,13
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,18
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,1
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,1
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,1
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,1
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,1
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,2
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,2
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,3
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,4
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,5
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,7
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,9
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,13
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,1
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,2
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,4
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,6
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,1
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,1
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,3
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,1
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,1
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,1
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,1
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,1
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,0
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,0
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,0
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,0
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,0
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,0
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,0
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,0
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,0
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,1
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,1
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,1
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,2
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,2
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,1
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,1
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,1
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,2
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,1
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,1
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,1
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,1
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,1
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,1
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,2
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,2
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,3
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,4
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,0
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,1
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,1
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,1
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,1
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,2
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,2
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,2
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,3
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,4
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,5
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,6
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,8
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,11
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,0
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,0
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,0
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,1
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,1
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,1
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,1
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,2
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,2
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,3
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,4
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,6
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,8
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,1
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,2
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,3
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,4
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,1
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,2
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,1
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,1
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,2
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,2
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,2
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,2
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,3
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,5
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,6
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,7
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,1
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,1
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,1
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,2
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,2
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,3
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,3
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,4
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,5
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,5
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,6
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,8
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,10
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,14
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,17
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,23
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,1
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,1
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,1
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,1
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,2
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,2
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,2
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,3
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,4
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,5
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,6
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,9
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,12
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,17
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,2
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,3
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,5
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,8
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,1
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,2
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,4
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,1
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,1
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,1
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,1
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,2
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,0
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,0
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,0
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,0
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,0
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,0
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,0
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,1
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,1
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,1
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,1
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,2
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,3
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,4
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,1
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,1
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,1
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,2
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,3
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,1
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,2
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,1
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,1
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,2
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,2
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,2
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,3
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,4
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,5
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,6
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,1
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,1
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,1
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,2
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,2
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,3
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,3
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,4
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,4
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,5
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,6
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,8
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,11
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,15
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,19
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,1
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,1
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,1
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,1
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,2
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,2
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,2
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,3
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,4
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,5
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,7
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,10
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,15
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,2
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,3
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,4
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,7
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,1
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,2
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,3
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,1

--- a/data-forecasts/sentinel-inla/2023-05-31-sentinel-inla.csv
+++ b/data-forecasts/sentinel-inla/2023-05-31-sentinel-inla.csv
@@ -1,0 +1,7890 @@
+location,forecast_date,target_end_date,target,type,quantile,value
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+Alabama,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,0
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,1
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,1
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,1
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,2
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,2
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,2
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,2
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,2
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,2
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,2
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,2
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,2
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,2
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,2
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,2
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,2
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,2
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,2
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,2
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,2
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,2
+Alabama,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,2
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,5
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,5
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,5
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,5
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,6
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,6
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,6
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,6
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,6
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,6
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,6
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,6
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,6
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,6
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,6
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,6
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,7
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,7
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,7
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,7
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,7
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,8
+Alabama,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,8
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,4
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,4
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,4
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,4
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,4
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,4
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,4
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,4
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,4
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,4
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,5
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,5
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,5
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,5
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,5
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,5
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,5
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,5
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,5
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,5
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,6
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,6
+Alabama,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,6
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,1
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,1
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,1
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,1
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,1
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,1
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,1
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,1
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,1
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,1
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,1
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,1
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,1
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,1
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,1
+Alabama,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,1
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Alabama,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Alabama,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+Arizona,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,0
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,1
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,1
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,2
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,2
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,2
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,2
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,2
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,2
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,2
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,2
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,2
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,2
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,2
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,2
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,2
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,2
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,2
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,2
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,2
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,2
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,3
+Arizona,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,3
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,5
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,5
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,5
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,6
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,6
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,6
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,6
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,6
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,6
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,7
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,7
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,7
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,7
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,7
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,7
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,7
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,8
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,8
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,8
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,8
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,9
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,9
+Arizona,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,10
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,4
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,4
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,4
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,4
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,4
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,5
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,5
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,5
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,5
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,5
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,5
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,5
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,5
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,5
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,5
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,6
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,6
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,6
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,6
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,6
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,7
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,7
+Arizona,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,7
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,1
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,1
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,1
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,1
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,1
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,1
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,1
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,1
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,1
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,1
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,1
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,1
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,1
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,1
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,1
+Arizona,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,1
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Arizona,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Arizona,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,3
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,3
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,4
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,4
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,4
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,4
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,4
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,4
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,4
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,4
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,4
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,4
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,4
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,4
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,4
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,5
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,5
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,5
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,5
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,5
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,5
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,5
+Arkansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,6
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,27
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,28
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,29
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,30
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,31
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,31
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,32
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,33
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,33
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,34
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,34
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,34
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,35
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,35
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,36
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,37
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,37
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,38
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,39
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,40
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,41
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,43
+Arkansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,44
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,93
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,97
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,100
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,104
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,107
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,110
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,112
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,113
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,115
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,117
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,119
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,120
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,122
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,124
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,126
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,127
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,130
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,132
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,135
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,139
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,144
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,150
+Arkansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,155
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,70
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,73
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,75
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,78
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,81
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,82
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,84
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,85
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,87
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,88
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,89
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,90
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,92
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,93
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,94
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,96
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,97
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,99
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,102
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,104
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,109
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,112
+Arkansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,116
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,13
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,13
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,14
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,14
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,14
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,15
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,15
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,15
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,16
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,16
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,16
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,16
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,16
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,17
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,17
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,17
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,17
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,18
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,18
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,19
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,19
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,20
+Arkansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,21
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,2
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,2
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,2
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,2
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,2
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,2
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,2
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,2
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,3
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,3
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,3
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,3
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,3
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,3
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,3
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,3
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,3
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,3
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,3
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,3
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,3
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,3
+Arkansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,4
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,1
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,1
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,1
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,1
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,1
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,1
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,1
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,1
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,1
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,1
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,1
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,1
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,1
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,1
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,1
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Arkansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,1
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,3
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,3
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,3
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,4
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,4
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,4
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,4
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,4
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,4
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,4
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,4
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,4
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,4
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,4
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,4
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,4
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,5
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,5
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,5
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,5
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,5
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,5
+California,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,5
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,26
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,28
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,28
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,30
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,30
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,31
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,32
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,32
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,33
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,33
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,33
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,34
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,34
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,35
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,35
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,36
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,36
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,37
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,38
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,39
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,40
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,41
+California,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,43
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,93
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,96
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,99
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,103
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,106
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,108
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,110
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,112
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,114
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,115
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,117
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,118
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,120
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,121
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,123
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,125
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,127
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,129
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,132
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,135
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,140
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,145
+California,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,151
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,70
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,72
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,75
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,78
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,80
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,81
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,83
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,84
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,85
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,86
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,88
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,89
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,90
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,91
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,92
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,94
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,95
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,97
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,99
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,102
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,105
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,109
+California,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,114
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,12
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,13
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,13
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,14
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,14
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,15
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,15
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,15
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,15
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,16
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,16
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,16
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,16
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,16
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,17
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,17
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,17
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,17
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,18
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,18
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,19
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,20
+California,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,20
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,2
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,2
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,2
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,2
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,2
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,2
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,2
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,2
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,2
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,3
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,3
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,3
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,3
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,3
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,3
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,3
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,3
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,3
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,3
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,3
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,3
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,3
+California,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,3
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,1
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,1
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,1
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,1
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,1
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,1
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,1
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,1
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,1
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,1
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,1
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,1
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,1
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,1
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,1
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+California,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,1
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,1
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,1
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,1
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,1
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,1
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,1
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,1
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,1
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,1
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,1
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,1
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,1
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,1
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,1
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,1
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,1
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,1
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,1
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,1
+Colorado,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,1
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,5
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,6
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,6
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,6
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,6
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,6
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,7
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,7
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,7
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,7
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,7
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,7
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,7
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,7
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,7
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,7
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,8
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,8
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,8
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,8
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,8
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,9
+Colorado,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,9
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,19
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,20
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,20
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,21
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,22
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,22
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,23
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,23
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,24
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,24
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,24
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,25
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,25
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,25
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,26
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,26
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,26
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,27
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,28
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,28
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,29
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,30
+Colorado,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,32
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,14
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,15
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,15
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,16
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,16
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,17
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,17
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,17
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,18
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,18
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,18
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,18
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,19
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,19
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,19
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,20
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,20
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,20
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,21
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,21
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,22
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,23
+Colorado,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,24
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,3
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,3
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,3
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,3
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,3
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,3
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,3
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,3
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,3
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,3
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,3
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,3
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,3
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,3
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,3
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,4
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,4
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,4
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,4
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,4
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,4
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,4
+Colorado,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,4
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,1
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,1
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,1
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,1
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,1
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,1
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,1
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,1
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,1
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,1
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,1
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,1
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,1
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,1
+Colorado,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,1
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Colorado,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+Connecticut,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,0
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,1
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,1
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,1
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,1
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,1
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,1
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,1
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,1
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,1
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,1
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,1
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,1
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,1
+Connecticut,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,1
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,2
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,2
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,2
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,2
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,2
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,2
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,2
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,2
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,2
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,2
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,2
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,2
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,2
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,3
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,3
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,3
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,3
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,3
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,3
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,3
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,3
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,3
+Connecticut,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,3
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,1
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,1
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,1
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,1
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,2
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,2
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,2
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,2
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,2
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,2
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,2
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,2
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,2
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,2
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,2
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,2
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,2
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,2
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,2
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,2
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,2
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,2
+Connecticut,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,3
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,0
+Connecticut,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Connecticut,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Connecticut,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+Delaware,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,0
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,1
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,1
+Delaware,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,1
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,1
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,1
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,1
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,1
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,1
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,1
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,1
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,1
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,1
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,1
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,1
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,1
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,1
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,1
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,2
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,2
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,2
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,2
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,2
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,2
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,2
+Delaware,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,2
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,1
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,1
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,1
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,1
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,1
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,1
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,1
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,1
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,1
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,1
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,1
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,1
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,1
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,1
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,1
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,1
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,1
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,1
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,1
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,1
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,1
+Delaware,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,2
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,0
+Delaware,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Delaware,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Delaware,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+District of Columbia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,0
+District of Columbia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,0
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,1
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,1
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,1
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,1
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,1
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,1
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,1
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,1
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,1
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,1
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,1
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,1
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,1
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,1
+District of Columbia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,1
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,0
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,1
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,1
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,1
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,1
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,1
+District of Columbia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,1
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,0
+District of Columbia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+District of Columbia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+District of Columbia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,1
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,1
+Florida,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,1
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,3
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,3
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,3
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,3
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,3
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,3
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,3
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,3
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,3
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,3
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,4
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,4
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,4
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,4
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,4
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,4
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,4
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,4
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,4
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,4
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,4
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,5
+Florida,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,5
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,9
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,10
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,10
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,11
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,11
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,11
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,11
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,12
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,12
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,12
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,12
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,12
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,13
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,13
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,13
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,13
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,14
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,14
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,14
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,15
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,16
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,16
+Florida,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,17
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,7
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,7
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,8
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,8
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,8
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,8
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,9
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,9
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,9
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,9
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,9
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,9
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,10
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,10
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,10
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,10
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,10
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,11
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,11
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,11
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,12
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,12
+Florida,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,13
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,1
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,1
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,1
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,1
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,1
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,2
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,2
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,2
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,2
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,2
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,2
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,2
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,2
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,2
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,2
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,2
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,2
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,2
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,2
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,2
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,2
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,2
+Florida,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,2
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Florida,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Florida,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+Georgia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,0
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,2
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,2
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,2
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,2
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,2
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,2
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,2
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,2
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,2
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,2
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,2
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,2
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,2
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,2
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,2
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,3
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,3
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,3
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,3
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,3
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,3
+Georgia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,3
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,6
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,6
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,6
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,7
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,7
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,7
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,7
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,7
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,8
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,8
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,8
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,8
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,8
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,8
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,8
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,9
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,9
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,9
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,9
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,10
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,10
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,10
+Georgia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,11
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,4
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,5
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,5
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,5
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,5
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,5
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,6
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,6
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,6
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,6
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,6
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,6
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,6
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,6
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,6
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,6
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,7
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,7
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,7
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,7
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,8
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,8
+Georgia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,8
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,1
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,1
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,1
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,1
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,1
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,1
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,1
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,1
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,1
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,1
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,1
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,1
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,1
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,1
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,1
+Georgia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,2
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Georgia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Georgia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+Idaho,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,0
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,1
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,1
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,1
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,1
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,1
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,2
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,2
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,2
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,2
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,2
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,2
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,2
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,2
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,2
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,2
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,2
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,2
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,2
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,2
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,2
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,2
+Idaho,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,2
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,4
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,5
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,5
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,5
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,5
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,5
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,5
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,6
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,6
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,6
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,6
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,6
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,6
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,6
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,6
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,6
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,7
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,7
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,7
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,7
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,8
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,8
+Idaho,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,8
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,3
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,3
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,4
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,4
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,4
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,4
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,4
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,4
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,4
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,4
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,4
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,4
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,5
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,5
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,5
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,5
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,5
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,5
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,5
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,5
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,6
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,6
+Idaho,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,6
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,1
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,1
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,1
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,1
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,1
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,1
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,1
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,1
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,1
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,1
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,1
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,1
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,1
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,1
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,1
+Idaho,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,1
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Idaho,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Idaho,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+Illinois,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,0
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,1
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,1
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,1
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,1
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,1
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,1
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,1
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,2
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,2
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,2
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,2
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,2
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,2
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,2
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,2
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,2
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,2
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,2
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,2
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,2
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,2
+Illinois,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,2
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,4
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,4
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,4
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,5
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,5
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,5
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,5
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,5
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,5
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,5
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,6
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,6
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,6
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,6
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,6
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,6
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,6
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,6
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,7
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,7
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,7
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,8
+Illinois,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,8
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,3
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,3
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,3
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,4
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,4
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,4
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,4
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,4
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,4
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,4
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,4
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,4
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,4
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,4
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,5
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,5
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,5
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,5
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,5
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,5
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,5
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,6
+Illinois,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,6
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,1
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,1
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,1
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,1
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,1
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,1
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,1
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,1
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,1
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,1
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,1
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,1
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,1
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,1
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,1
+Illinois,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,1
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Illinois,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Illinois,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,1
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,1
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,1
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,1
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,1
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,1
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,1
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,1
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,1
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,1
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,1
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,1
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,1
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,1
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,1
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,1
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,1
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,1
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,1
+Indiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,1
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,4
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,5
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,5
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,5
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,5
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,5
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,5
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,6
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,6
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,6
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,6
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,6
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,6
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,6
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,6
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,6
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,6
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,6
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,7
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,7
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,7
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,7
+Indiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,8
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,16
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,16
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,17
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,18
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,18
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,19
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,19
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,19
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,20
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,20
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,20
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,20
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,21
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,21
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,21
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,22
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,22
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,23
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,23
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,24
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,25
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,26
+Indiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,27
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,12
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,12
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,13
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,13
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,14
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,14
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,14
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,15
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,15
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,15
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,15
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,15
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,16
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,16
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,16
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,16
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,17
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,17
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,17
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,18
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,19
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,19
+Indiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,20
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,2
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,2
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,2
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,2
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,2
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,3
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,3
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,3
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,3
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,3
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,3
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,3
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,3
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,3
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,3
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,3
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,3
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,3
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,3
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,3
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,3
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,4
+Indiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,4
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,1
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,1
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,1
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,1
+Indiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,1
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Indiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+Iowa,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,0
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,1
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,1
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,1
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,1
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,1
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,2
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,2
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,2
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,2
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,2
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,2
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,2
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,2
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,2
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,2
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,2
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,2
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,2
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,2
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,2
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,2
+Iowa,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,2
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,4
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,4
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,5
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,5
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,5
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,5
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,5
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,6
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,6
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,6
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,6
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,6
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,6
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,6
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,6
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,6
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,7
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,7
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,7
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,7
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,7
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,8
+Iowa,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,8
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,3
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,3
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,4
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,4
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,4
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,4
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,4
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,4
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,4
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,4
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,4
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,4
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,5
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,5
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,5
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,5
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,5
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,5
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,5
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,5
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,6
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,6
+Iowa,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,6
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,1
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,1
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,1
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,1
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,1
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,1
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,1
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,1
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,1
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,1
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,1
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,1
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,1
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,1
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,1
+Iowa,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,1
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Iowa,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Iowa,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+Kansas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,0
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,2
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,2
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,2
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,2
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,2
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,2
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,2
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,2
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,2
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,2
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,2
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,2
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,2
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,2
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,3
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,3
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,3
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,3
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,3
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,3
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,3
+Kansas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,3
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,6
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,6
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,7
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,7
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,7
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,7
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,7
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,8
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,8
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,8
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,8
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,8
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,8
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,8
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,9
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,9
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,9
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,9
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,9
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,10
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,10
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,11
+Kansas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,11
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,4
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,5
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,5
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,5
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,5
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,5
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,6
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,6
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,6
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,6
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,6
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,6
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,6
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,6
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,7
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,7
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,7
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,7
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,7
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,7
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,8
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,8
+Kansas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,8
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,1
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,1
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,1
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,1
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,1
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,1
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,1
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,1
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,1
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,1
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,1
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,1
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,1
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,1
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,1
+Kansas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,2
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Kansas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Kansas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+Kentucky,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,0
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,1
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,1
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,1
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,1
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,1
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,1
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,1
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,1
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,1
+Kentucky,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,1
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,1
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,1
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,2
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,2
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,2
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,2
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,2
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,2
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,2
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,2
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,2
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,2
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,2
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,2
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,2
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,2
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,2
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,2
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,2
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,3
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,3
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,3
+Kentucky,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,3
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,1
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,1
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,1
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,1
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,1
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,1
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,1
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,1
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,1
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,2
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,2
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,2
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,2
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,2
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,2
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,2
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,2
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,2
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,2
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,2
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,2
+Kentucky,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,2
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,0
+Kentucky,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Kentucky,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Kentucky,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,1
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,1
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,1
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,1
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,1
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,1
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,1
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,1
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,1
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,1
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,1
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,1
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,1
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,1
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,1
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,1
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,1
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,1
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,2
+Louisiana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,2
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,8
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,8
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,8
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,8
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,9
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,9
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,9
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,9
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,9
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,10
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,10
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,10
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,10
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,10
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,10
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,10
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,11
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,11
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,11
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,11
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,12
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,12
+Louisiana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,13
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,26
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,27
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,28
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,29
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,30
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,31
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,31
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,32
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,33
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,33
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,34
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,34
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,35
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,35
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,36
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,36
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,37
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,38
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,38
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,39
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,41
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,42
+Louisiana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,45
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,20
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,20
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,21
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,22
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,23
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,23
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,24
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,24
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,25
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,25
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,25
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,26
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,26
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,26
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,27
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,27
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,28
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,28
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,29
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,30
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,31
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,32
+Louisiana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,34
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,4
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,4
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,4
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,4
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,4
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,4
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,4
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,4
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,4
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,4
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,5
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,5
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,5
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,5
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,5
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,5
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,5
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,5
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,5
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,5
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,6
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,6
+Louisiana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,6
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,1
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,1
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,1
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,1
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,1
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,1
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,1
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,1
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,1
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,1
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,1
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,1
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,1
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,1
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,1
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,1
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,1
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,1
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,1
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,1
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,1
+Louisiana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,1
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Louisiana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+Maine,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,0
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,1
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,1
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,1
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,1
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,1
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,1
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,1
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,1
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,1
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,1
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,1
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,1
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,1
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,1
+Maine,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,1
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,3
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,3
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,3
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,3
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,3
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,3
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,3
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,3
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,3
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,3
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,4
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,4
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,4
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,4
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,4
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,4
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,4
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,4
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,4
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,4
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,5
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,5
+Maine,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,5
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,2
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,2
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,2
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,2
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,2
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,2
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,2
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,2
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,3
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,3
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,3
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,3
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,3
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,3
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,3
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,3
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,3
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,3
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,3
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,3
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,3
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,4
+Maine,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,4
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,1
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,1
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,1
+Maine,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,1
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Maine,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Maine,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+Maryland,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,0
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,1
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,1
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,1
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,1
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,1
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,1
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,1
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,1
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,1
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,2
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,2
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,2
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,2
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,2
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,2
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,2
+Maryland,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,2
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,4
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,4
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,4
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,4
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,4
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,4
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,5
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,5
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,5
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,5
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,5
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,5
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,5
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,5
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,5
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,5
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,5
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,6
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,6
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,6
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,6
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,7
+Maryland,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,7
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,3
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,3
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,3
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,3
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,3
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,3
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,3
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,3
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,4
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,4
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,4
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,4
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,4
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,4
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,4
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,4
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,4
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,4
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,4
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,4
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,5
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,5
+Maryland,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,5
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,1
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,1
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,1
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,1
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,1
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,1
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,1
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,1
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,1
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,1
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,1
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,1
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,1
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,1
+Maryland,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,1
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Maryland,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Maryland,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+Massachusetts,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,0
+Massachusetts,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,0
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,1
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,1
+Massachusetts,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,1
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,0
+Massachusetts,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,1
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,0
+Massachusetts,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Massachusetts,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Massachusetts,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+Michigan,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,1
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,2
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,2
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,2
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,3
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,3
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,3
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,3
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,3
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,3
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,3
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,3
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,3
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,3
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,3
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,3
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,3
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,3
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,3
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,3
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,4
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,4
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,4
+Michigan,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,4
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,8
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,8
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,8
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,9
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,9
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,9
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,10
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,10
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,10
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,10
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,10
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,10
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,11
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,11
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,11
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,11
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,11
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,12
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,12
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,12
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,13
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,13
+Michigan,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,14
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,6
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,6
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,6
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,7
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,7
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,7
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,7
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,7
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,7
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,8
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,8
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,8
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,8
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,8
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,8
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,8
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,9
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,9
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,9
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,9
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,10
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,10
+Michigan,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,11
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,1
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,1
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,1
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,1
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,1
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,1
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,1
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,1
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,1
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,1
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,1
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,1
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,2
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,2
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,2
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,2
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,2
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,2
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,2
+Michigan,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,2
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Michigan,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Michigan,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+Minnesota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,0
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,2
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,2
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,2
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,2
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,2
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,2
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,2
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,2
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,2
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,2
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,2
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,2
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,2
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,2
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,2
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,2
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,2
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,2
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,2
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,3
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,3
+Minnesota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,3
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,5
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,6
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,6
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,6
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,6
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,7
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,7
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,7
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,7
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,7
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,7
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,7
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,7
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,8
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,8
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,8
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,8
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,8
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,8
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,9
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,9
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,9
+Minnesota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,10
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,4
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,4
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,4
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,5
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,5
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,5
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,5
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,5
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,5
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,5
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,5
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,5
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,6
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,6
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,6
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,6
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,6
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,6
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,6
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,7
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,7
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,7
+Minnesota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,7
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,1
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,1
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,1
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,1
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,1
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,1
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,1
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,1
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,1
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,1
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,1
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,1
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,1
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,1
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,1
+Minnesota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,1
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Minnesota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Minnesota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+Mississippi,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,0
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,2
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,2
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,2
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,2
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,2
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,2
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,2
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,2
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,2
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,2
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,2
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,2
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,2
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,2
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,3
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,3
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,3
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,3
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,3
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,3
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,3
+Mississippi,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,3
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,6
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,6
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,7
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,7
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,7
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,7
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,7
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,8
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,8
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,8
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,8
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,8
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,8
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,8
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,9
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,9
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,9
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,9
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,9
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,10
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,10
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,11
+Mississippi,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,11
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,4
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,5
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,5
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,5
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,5
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,5
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,6
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,6
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,6
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,6
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,6
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,6
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,6
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,6
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,6
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,7
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,7
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,7
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,7
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,7
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,8
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,8
+Mississippi,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,8
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,1
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,1
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,1
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,1
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,1
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,1
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,1
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,1
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,1
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,1
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,1
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,1
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,1
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,1
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,1
+Mississippi,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,2
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Mississippi,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Mississippi,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,1
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,1
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,1
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,1
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,1
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,1
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,1
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,1
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,1
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,1
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,1
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,1
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,1
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,1
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,1
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,1
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,1
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,1
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,1
+Missouri,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,1
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,4
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,4
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,4
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,5
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,5
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,5
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,5
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,5
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,5
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,5
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,5
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,6
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,6
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,6
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,6
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,6
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,6
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,6
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,6
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,7
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,7
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,7
+Missouri,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,7
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,14
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,15
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,16
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,16
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,17
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,17
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,18
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,18
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,18
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,19
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,19
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,19
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,20
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,20
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,20
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,21
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,21
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,22
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,22
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,23
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,24
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,25
+Missouri,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,26
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,11
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,11
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,12
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,12
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,13
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,13
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,13
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,14
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,14
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,14
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,14
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,15
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,15
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,15
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,15
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,16
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,16
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,16
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,17
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,17
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,18
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,19
+Missouri,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,20
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,2
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,2
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,2
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,2
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,2
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,2
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,2
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,2
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,2
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,3
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,3
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,3
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,3
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,3
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,3
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,3
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,3
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,3
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,3
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,3
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,3
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,3
+Missouri,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,4
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,1
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,1
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,1
+Missouri,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,1
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Missouri,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+Montana,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,0
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,1
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,1
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,1
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,1
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,1
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,1
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,1
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,1
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,1
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,1
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,1
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,1
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,1
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,1
+Montana,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,1
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,2
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,3
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,3
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,3
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,3
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,3
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,3
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,3
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,3
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,3
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,3
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,3
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,3
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,3
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,4
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,4
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,4
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,4
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,4
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,4
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,4
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,4
+Montana,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,5
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,2
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,2
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,2
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,2
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,2
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,2
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,2
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,2
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,2
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,2
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,2
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,3
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,3
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,3
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,3
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,3
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,3
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,3
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,3
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,3
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,3
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,3
+Montana,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,4
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,1
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,1
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,1
+Montana,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,1
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Montana,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Montana,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+Nebraska,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,0
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,1
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,1
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,1
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,1
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,1
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,1
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,1
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,1
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,1
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,1
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,1
+Nebraska,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,1
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,1
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,2
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,2
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,2
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,2
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,2
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,2
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,2
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,2
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,2
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,2
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,2
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,2
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,2
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,2
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,2
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,2
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,3
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,3
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,3
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,3
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,3
+Nebraska,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,3
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,1
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,1
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,1
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,1
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,1
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,1
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,1
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,2
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,2
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,2
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,2
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,2
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,2
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,2
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,2
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,2
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,2
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,2
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,2
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,2
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,2
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,2
+Nebraska,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,2
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,0
+Nebraska,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Nebraska,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Nebraska,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+Nevada,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,0
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,2
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,2
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,2
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,2
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,2
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,2
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,2
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,2
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,2
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,2
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,2
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,2
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,2
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,2
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,2
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,2
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,3
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,3
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,3
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,3
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,3
+Nevada,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,3
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,6
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,6
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,6
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,7
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,7
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,7
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,7
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,7
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,7
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,8
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,8
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,8
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,8
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,8
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,8
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,8
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,9
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,9
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,9
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,9
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,10
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,10
+Nevada,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,11
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,4
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,5
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,5
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,5
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,5
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,5
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,5
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,6
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,6
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,6
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,6
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,6
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,6
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,6
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,6
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,6
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,6
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,7
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,7
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,7
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,7
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,8
+Nevada,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,8
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,1
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,1
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,1
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,1
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,1
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,1
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,1
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,1
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,1
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,1
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,1
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,1
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,1
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,1
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,1
+Nevada,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,1
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Nevada,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Nevada,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,1
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,1
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,1
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,1
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,1
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,1
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,1
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,1
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,1
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,1
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,1
+New Hampshire,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,1
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,3
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,3
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,3
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,4
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,4
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,4
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,4
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,4
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,4
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,4
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,4
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,4
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,4
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,4
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,4
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,5
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,5
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,5
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,5
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,5
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,5
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,5
+New Hampshire,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,6
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,11
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,12
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,12
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,13
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,13
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,13
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,14
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,14
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,14
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,14
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,15
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,15
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,15
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,15
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,16
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,16
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,16
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,16
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,17
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,17
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,18
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,19
+New Hampshire,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,20
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,8
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,9
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,9
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,10
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,10
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,10
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,10
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,10
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,11
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,11
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,11
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,11
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,11
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,11
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,12
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,12
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,12
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,12
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,13
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,13
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,14
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,14
+New Hampshire,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,15
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,2
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,2
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,2
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,2
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,2
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,2
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,2
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,2
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,2
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,2
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,2
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,2
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,2
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,2
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,2
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,2
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,2
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,2
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,2
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,2
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,2
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,3
+New Hampshire,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,3
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+New Hampshire,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+New Hampshire,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+New Jersey,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,0
+New Jersey,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,0
+New Jersey,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,0
+New Jersey,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,0
+New Jersey,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+New Jersey,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+New Jersey,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+New Mexico,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,0
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,1
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,1
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,1
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,1
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,1
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,1
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,1
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,1
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,1
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,2
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,2
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,2
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,2
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,2
+New Mexico,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,2
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,3
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,4
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,4
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,4
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,4
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,4
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,4
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,4
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,4
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,5
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,5
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,5
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,5
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,5
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,5
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,5
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,5
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,5
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,5
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,6
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,6
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,6
+New Mexico,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,7
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,3
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,3
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,3
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,3
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,3
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,3
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,3
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,3
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,3
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,3
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,3
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,4
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,4
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,4
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,4
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,4
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,4
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,4
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,4
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,4
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,4
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,5
+New Mexico,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,5
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,1
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,1
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,1
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,1
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,1
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,1
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,1
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,1
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,1
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,1
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,1
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,1
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,1
+New Mexico,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,1
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+New Mexico,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+New Mexico,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+New York,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,0
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,1
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,2
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,2
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,2
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,2
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,2
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,2
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,2
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,2
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,2
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,2
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,2
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,2
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,2
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,2
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,2
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,2
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,2
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,2
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,3
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,3
+New York,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,3
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,5
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,5
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,6
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,6
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,6
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,6
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,7
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,7
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,7
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,7
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,7
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,7
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,7
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,7
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,8
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,8
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,8
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,8
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,8
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,9
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,9
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,9
+New York,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,10
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,4
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,4
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,4
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,5
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,5
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,5
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,5
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,5
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,5
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,5
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,5
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,5
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,5
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,6
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,6
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,6
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,6
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,6
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,6
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,6
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,7
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,7
+New York,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,7
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,1
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,1
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,1
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,1
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,1
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,1
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,1
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,1
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,1
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,1
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,1
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,1
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,1
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,1
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,1
+New York,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,1
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+New York,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+New York,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+North Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,0
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,1
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,1
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,1
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,1
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,1
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,1
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,1
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,1
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,1
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,2
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,2
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,2
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,2
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,2
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,2
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,2
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,2
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,2
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,2
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,2
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,2
+North Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,2
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,4
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,4
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,4
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,4
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,5
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,5
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,5
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,5
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,5
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,5
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,5
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,5
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,5
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,6
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,6
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,6
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,6
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,6
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,6
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,7
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,7
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,7
+North Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,8
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,3
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,3
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,3
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,3
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,3
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,4
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,4
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,4
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,4
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,4
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,4
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,4
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,4
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,4
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,4
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,4
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,4
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,5
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,5
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,5
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,5
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,5
+North Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,6
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,1
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,1
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,1
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,1
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,1
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,1
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,1
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,1
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,1
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,1
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,1
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,1
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,1
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,1
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,1
+North Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,1
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+North Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+North Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,1
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,1
+North Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,1
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,3
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,3
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,3
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,3
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,3
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,3
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,3
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,3
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,3
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,3
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,4
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,4
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,4
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,4
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,4
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,4
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,4
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,4
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,4
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,4
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,4
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,5
+North Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,5
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,10
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,10
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,10
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,11
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,11
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,11
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,12
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,12
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,12
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,12
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,12
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,13
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,13
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,13
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,13
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,13
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,14
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,14
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,14
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,15
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,15
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,16
+North Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,16
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,7
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,8
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,8
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,8
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,8
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,9
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,9
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,9
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,9
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,9
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,9
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,9
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,10
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,10
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,10
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,10
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,10
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,10
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,11
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,11
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,11
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,12
+North Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,12
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,1
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,1
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,1
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,1
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,1
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,2
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,2
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,2
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,2
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,2
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,2
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,2
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,2
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,2
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,2
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,2
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,2
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,2
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,2
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,2
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,2
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,2
+North Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,2
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+North Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+North Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+Ohio,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,0
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,2
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,2
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,2
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,2
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,2
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,2
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,2
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,2
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,2
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,2
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,2
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,2
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,2
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,2
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,3
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,3
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,3
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,3
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,3
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,3
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,3
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,3
+Ohio,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,3
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,6
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,6
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,7
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,7
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,7
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,7
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,8
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,8
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,8
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,8
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,8
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,8
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,8
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,9
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,9
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,9
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,9
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,9
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,9
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,10
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,10
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,11
+Ohio,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,11
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,5
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,5
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,5
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,5
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,5
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,6
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,6
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,6
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,6
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,6
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,6
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,6
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,6
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,6
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,7
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,7
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,7
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,7
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,7
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,7
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,8
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,8
+Ohio,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,8
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,1
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,1
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,1
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,1
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,1
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,1
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,1
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,1
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,1
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,1
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,1
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,1
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,1
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,1
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,1
+Ohio,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,2
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Ohio,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Ohio,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,1
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,1
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,1
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,1
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,1
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,1
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,1
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,1
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,1
+Oklahoma,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,1
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,3
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,3
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,3
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,3
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,4
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,4
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,4
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,4
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,4
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,4
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,4
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,4
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,4
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,4
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,4
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,4
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,4
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,4
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,5
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,5
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,5
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,5
+Oklahoma,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,5
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,10
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,11
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,11
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,12
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,12
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,13
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,13
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,13
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,13
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,14
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,14
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,14
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,14
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,14
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,15
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,15
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,15
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,16
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,16
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,17
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,17
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,18
+Oklahoma,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,19
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,8
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,8
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,9
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,9
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,9
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,9
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,10
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,10
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,10
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,10
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,10
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,11
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,11
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,11
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,11
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,11
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,11
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,12
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,12
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,12
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,13
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,14
+Oklahoma,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,14
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,1
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,1
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,2
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,2
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,2
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,2
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,2
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,2
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,2
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,2
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,2
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,2
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,2
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,2
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,2
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,2
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,2
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,2
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,2
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,2
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,2
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,2
+Oklahoma,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,3
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Oklahoma,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Oklahoma,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+Oregon,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,0
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,1
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,1
+Oregon,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,1
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,1
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,1
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,1
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,1
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,1
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,1
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,1
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,1
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,1
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,1
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,1
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,1
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,1
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,1
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,1
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,1
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,1
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,1
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,2
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,2
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,2
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,2
+Oregon,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,2
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,1
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,1
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,1
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,1
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,1
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,1
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,1
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,1
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,1
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,1
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,1
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,1
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,1
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,1
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,1
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,1
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,1
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,1
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,1
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,1
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,1
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,1
+Oregon,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,1
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,0
+Oregon,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Oregon,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Oregon,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+Pennsylvania,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,0
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,2
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,2
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,2
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,2
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,3
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,3
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,3
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,3
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,3
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,3
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,3
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,3
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,3
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,3
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,3
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,3
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,3
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,3
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,3
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,3
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,4
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,4
+Pennsylvania,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,4
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,8
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,8
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,8
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,9
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,9
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,9
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,9
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,9
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,10
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,10
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,10
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,10
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,10
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,10
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,11
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,11
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,11
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,11
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,11
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,12
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,12
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,13
+Pennsylvania,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,13
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,6
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,6
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,6
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,6
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,7
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,7
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,7
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,7
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,7
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,7
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,7
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,8
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,8
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,8
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,8
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,8
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,8
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,8
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,9
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,9
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,9
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,10
+Pennsylvania,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,10
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,1
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,1
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,1
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,1
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,1
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,1
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,1
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,1
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,1
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,1
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,1
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,1
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,2
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,2
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,2
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,2
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,2
+Pennsylvania,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,2
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Pennsylvania,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Pennsylvania,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+Rhode Island,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,0
+Rhode Island,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,0
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,1
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,1
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,1
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,1
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,1
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,1
+Rhode Island,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,1
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,0
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,1
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,1
+Rhode Island,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,1
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,0
+Rhode Island,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Rhode Island,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Rhode Island,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+South Carolina,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,0
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,1
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,1
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,1
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,1
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,1
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,1
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,1
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,1
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,1
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,1
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,1
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,1
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,1
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,1
+South Carolina,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,1
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,2
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,2
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,2
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,2
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,2
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,2
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,2
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,3
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,3
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,3
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,3
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,3
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,3
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,3
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,3
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,3
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,3
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,3
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,3
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,3
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,4
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,4
+South Carolina,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,4
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,1
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,1
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,2
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,2
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,2
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,2
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,2
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,2
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,2
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,2
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,2
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,2
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,2
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,2
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,2
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,2
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,2
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,2
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,2
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,3
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,3
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,3
+South Carolina,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,3
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,0
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,1
+South Carolina,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,1
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+South Carolina,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+South Carolina,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,1
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,1
+South Dakota,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,1
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,2
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,3
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,3
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,3
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,3
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,3
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,3
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,3
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,3
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,3
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,3
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,3
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,3
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,3
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,3
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,3
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,3
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,4
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,4
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,4
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,4
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,4
+South Dakota,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,4
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,8
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,9
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,9
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,9
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,10
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,10
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,10
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,10
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,11
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,11
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,11
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,11
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,11
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,11
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,12
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,12
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,12
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,12
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,13
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,13
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,14
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,14
+South Dakota,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,15
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,6
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,7
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,7
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,7
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,7
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,8
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,8
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,8
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,8
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,8
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,8
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,8
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,9
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,9
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,9
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,9
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,9
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,9
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,10
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,10
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,10
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,11
+South Dakota,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,11
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,1
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,1
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,1
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,1
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,1
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,1
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,1
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,1
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,1
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,1
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,1
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,2
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,2
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,2
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,2
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,2
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,2
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,2
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,2
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,2
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,2
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,2
+South Dakota,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,2
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+South Dakota,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+South Dakota,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+Tennessee,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,0
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,1
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,1
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,1
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,1
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,1
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,1
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,1
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,1
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,1
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,2
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,2
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,2
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,2
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,2
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,2
+Tennessee,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,2
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,3
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,4
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,4
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,4
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,4
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,4
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,4
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,4
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,5
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,5
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,5
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,5
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,5
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,5
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,5
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,5
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,5
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,5
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,6
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,6
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,6
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,6
+Tennessee,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,7
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,3
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,3
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,3
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,3
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,3
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,3
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,3
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,3
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,3
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,3
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,4
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,4
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,4
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,4
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,4
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,4
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,4
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,4
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,4
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,4
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,5
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,5
+Tennessee,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,5
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,1
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,1
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,1
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,1
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,1
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,1
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,1
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,1
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,1
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,1
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,1
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,1
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,1
+Tennessee,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,1
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Tennessee,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Tennessee,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,3
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,3
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,3
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,3
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,3
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,3
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,3
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,3
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,3
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,3
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,3
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,4
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,4
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,4
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,4
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,4
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,4
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,4
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,4
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,4
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,4
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,4
+Texas,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,5
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,22
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,23
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,24
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,25
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,25
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,26
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,26
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,27
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,27
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,27
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,28
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,28
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,29
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,29
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,29
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,30
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,30
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,31
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,32
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,32
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,34
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,35
+Texas,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,36
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,77
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,80
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,83
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,86
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,88
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,90
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,91
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,93
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,94
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,96
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,97
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,98
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,100
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,101
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,103
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,104
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,106
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,108
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,110
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,113
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,117
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,121
+Texas,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,126
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,58
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,60
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,62
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,65
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,66
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,68
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,69
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,70
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,71
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,72
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,73
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,74
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,75
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,76
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,77
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,78
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,80
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,81
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,83
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,85
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,88
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,91
+Texas,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,95
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,10
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,11
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,11
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,12
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,12
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,12
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,12
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,13
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,13
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,13
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,13
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,13
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,13
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,14
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,14
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,14
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,14
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,15
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,15
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,15
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,16
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,16
+Texas,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,17
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,2
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,2
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,2
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,2
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,2
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,2
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,2
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,2
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,2
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,2
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,2
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,2
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,2
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,2
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,2
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,2
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,2
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,2
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,2
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,3
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,3
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,3
+Texas,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,3
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,1
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,1
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,1
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,1
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,1
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,1
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,1
+Texas,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,1
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+Utah,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,0
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,1
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,1
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,1
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,1
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,1
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,1
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,1
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,1
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,1
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,1
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,1
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,2
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,2
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,2
+Utah,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,2
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,3
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,3
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,3
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,4
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,4
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,4
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,4
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,4
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,4
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,4
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,4
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,4
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,4
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,4
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,5
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,5
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,5
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,5
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,5
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,5
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,6
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,6
+Utah,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,6
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,2
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,2
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,3
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,3
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,3
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,3
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,3
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,3
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,3
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,3
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,3
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,3
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,3
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,3
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,3
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,4
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,4
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,4
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,4
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,4
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,4
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,4
+Utah,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,5
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,1
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,1
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,1
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,1
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,1
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,1
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,1
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,1
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,1
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,1
+Utah,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,1
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Utah,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Utah,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+Vermont,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,0
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,1
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,1
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,1
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,1
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,1
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,1
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,1
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,1
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,1
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,1
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,1
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,1
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,1
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,1
+Vermont,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,1
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,2
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,3
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,3
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,3
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,3
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,3
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,3
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,3
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,3
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,3
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,3
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,3
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,4
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,4
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,4
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,4
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,4
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,4
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,4
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,4
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,4
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,5
+Vermont,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,5
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,2
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,2
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,2
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,2
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,2
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,2
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,2
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,2
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,2
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,2
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,3
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,3
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,3
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,3
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,3
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,3
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,3
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,3
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,3
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,3
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,3
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,3
+Vermont,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,4
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,1
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,1
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,1
+Vermont,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,1
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Vermont,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Vermont,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,0
+Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,0
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,0
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,0
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,0
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,1
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,1
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,1
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,1
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,1
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,1
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,1
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,1
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,1
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,1
+Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,1
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,0
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,1
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,1
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,1
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,1
+Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,1
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,0
+Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+Washington,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,0
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,1
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,1
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,1
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,1
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,1
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,1
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,1
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,1
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,1
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,1
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,1
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,1
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,1
+Washington,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,1
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,2
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,2
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,2
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,2
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,2
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,2
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,2
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,2
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,2
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,2
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,3
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,3
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,3
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,3
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,3
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,3
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,3
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,3
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,3
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,3
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,4
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,4
+Washington,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,4
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,1
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,1
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,1
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,2
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,2
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,2
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,2
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,2
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,2
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,2
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,2
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,2
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,2
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,2
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,2
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,2
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,2
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,2
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,2
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,3
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,3
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,3
+Washington,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,3
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,0
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,1
+Washington,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,1
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Washington,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Washington,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+West Virginia,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,0
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,1
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,1
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,1
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,1
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,1
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,1
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,1
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,1
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,1
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,1
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,1
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,2
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,2
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,2
+West Virginia,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,2
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,3
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,3
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,4
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,4
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,4
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,4
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,4
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,4
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,4
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,4
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,4
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,4
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,5
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,5
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,5
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,5
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,5
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,5
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,5
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,5
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,6
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,6
+West Virginia,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,6
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,2
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,3
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,3
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,3
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,3
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,3
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,3
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,3
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,3
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,3
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,3
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,3
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,3
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,3
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,4
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,4
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,4
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,4
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,4
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,4
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,4
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,4
+West Virginia,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,5
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,1
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,1
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,1
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,1
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,1
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,1
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,1
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,1
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,1
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,1
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,1
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,1
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,1
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,1
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,1
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,1
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,1
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,1
+West Virginia,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,1
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+West Virginia,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+West Virginia,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+Wisconsin,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,0
+Wisconsin,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,0
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,0
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,0
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,0
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,0
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,0
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,0
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,0
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,0
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,0
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,0
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,0
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,0
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,0
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,0
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,0
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,0
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,0
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,1
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,1
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,1
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,1
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,1
+Wisconsin,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,1
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,0
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,1
+Wisconsin,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,1
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,0
+Wisconsin,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Wisconsin,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Wisconsin,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.01,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.025,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.05,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.1,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.15,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.2,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.25,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.3,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.35,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.4,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.45,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.5,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.55,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.6,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.65,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.7,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.75,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.8,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.85,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.9,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.95,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.975,0
+Wyoming,2023-05-31,2023-06-30,June WNV neuroinvasive disease cases,quantile,0.99,0
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.01,0
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.025,0
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.05,0
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.1,1
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.15,1
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.2,1
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.25,1
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.3,1
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.35,1
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.4,1
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.45,1
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.5,1
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.55,1
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.6,1
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.65,1
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.7,1
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.75,1
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.8,1
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.85,1
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.9,1
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.95,1
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.975,1
+Wyoming,2023-05-31,2023-07-31,July WNV neuroinvasive disease cases,quantile,0.99,1
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.01,2
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.025,2
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.05,2
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.1,2
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.15,2
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.2,2
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.25,2
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.3,2
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.35,2
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.4,2
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.45,2
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.5,2
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.55,2
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.6,2
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.65,2
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.7,2
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.75,3
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.8,3
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.85,3
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.9,3
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.95,3
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.975,3
+Wyoming,2023-05-31,2023-08-31,August WNV neuroinvasive disease cases,quantile,0.99,3
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.01,1
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.025,1
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.05,1
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.1,1
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.15,1
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.2,1
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.25,2
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.3,2
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.35,2
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.4,2
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.45,2
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.5,2
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.55,2
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.6,2
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.65,2
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.7,2
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.75,2
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.8,2
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.85,2
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.9,2
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.95,2
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.975,2
+Wyoming,2023-05-31,2023-09-30,September WNV neuroinvasive disease cases,quantile,0.99,3
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.01,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.025,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.05,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.1,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.15,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.2,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.25,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.3,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.35,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.4,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.45,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.5,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.55,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.6,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.65,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.7,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.75,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.8,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.85,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.9,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.95,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.975,0
+Wyoming,2023-05-31,2023-10-31,October WNV neuroinvasive disease cases,quantile,0.99,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.01,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.025,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.05,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.1,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.15,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.2,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.25,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.3,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.35,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.4,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.45,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.5,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.55,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.6,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.65,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.7,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.75,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.8,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.85,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.9,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.95,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.975,0
+Wyoming,2023-05-31,2023-11-30,November WNV neuroinvasive disease cases,quantile,0.99,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.01,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.025,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.05,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.1,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.15,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.2,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.25,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.3,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.35,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.4,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.45,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.5,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.55,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.6,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.65,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.7,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.75,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.8,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.85,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.9,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.95,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.975,0
+Wyoming,2023-05-31,2023-12-31,December WNV neuroinvasive disease cases,quantile,0.99,0


### PR DESCRIPTION
A couple of updates:

1. May forecasts are included for hhh4 and inla. Within sampling error, these should be the same as the April forecasts, just trimmed, as they are just baseline models and have not been developed since.
2. I have added a new folder, `sentinel-gamlss`, to succeed `sentinel-bamlss` - the latter was not working, and the new folder fits more-or-less the same model but with a different implementation. It turned out that bamlss was not optimizing all parameters, hence the crazy median fit for the April forecast. I managed to get gamlss working after some monkey-patching.